### PR TITLE
Redirect link to new org URL

### DIFF
--- a/docs/01_installation.md
+++ b/docs/01_installation.md
@@ -13,14 +13,14 @@ redirect_from:
 
 This library requires Spark 2.0+ (not tested for earlier version). The
 library has been tested with Scala 2.11. If you want to use
-another version, feel free to contact us. In addition to Spark, the library has currently two external dependencies: [healpix](http://healpix.sourceforge.net/) and [spark-fits](https://github.com/theastrolab/spark-fits). Unfortunately, there are no Maven coordinates for healpix, so we release a jar of the latest version within spark3D under the `lib/` folder.
+another version, feel free to contact us. In addition to Spark, the library has currently two external dependencies: [healpix](http://healpix.sourceforge.net/) and [spark-fits](https://github.com/astrolabsoftware/spark-fits). Unfortunately, there are no Maven coordinates for healpix, so we release a jar of the latest version within spark3D under the `lib/` folder.
 
 ## Including spark3D in your project
 
 You can link spark3D to your project (either `spark-shell` or `spark-submit`) by specifying the coordinates:
 
 ```bash
-toto:~$ spark-submit --packages "com.github.theastrolab:spark3d_2.11:0.1.1" <...>
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark3d_2.11:0.1.1" <...>
 ```
 
 It might not contain the latest features though (see *Building from source*).
@@ -70,7 +70,7 @@ First produce a jar of the spark3D library, and then launch a spark-shell by spe
 
 ```bash
 toto:~$ JARS="target/scala-2.11/spark3d_2.11-0.1.1.jar,lib/jhealpix.jar"
-toto:~$ PACKAGES="com.github.theastrolab:spark-fits_2.11:0.4.0"
+toto:~$ PACKAGES="com.github.astrolabsoftware:spark-fits_2.11:0.4.0"
 toto:~$ spark-shell --jars $JARS --packages $PACKAGES
 ```
 
@@ -89,7 +89,7 @@ toto:~$ spark-shell --jars $FATJARS
 
 ## Using with jupyter notebook and examples
 
-We include a number of notebooks to describe the use of the library in the folder `examples/jupyter`. We included a [README](https://github.com/theastrolab/spark3D/blob/master/examples/jupyter/README.md) to install Apache Toree as kernel in Jupyter.
+We include a number of notebooks to describe the use of the library in the folder `examples/jupyter`. We included a [README](https://github.com/astrolabsoftware/spark3D/blob/master/examples/jupyter/README.md) to install Apache Toree as kernel in Jupyter.
 
 ## Batch mode and provided examples
 
@@ -98,5 +98,5 @@ You can follow the different tutorials:
 - [Space partitioning]({{ site.baseurl }}{% link 03_partitioning.md %})
 - [Query]({{ site.baseurl }}{% link 04_query.md %})
 
-We also include [examples](https://github.com/theastrolab/spark3D/tree/master/src/main/scala/com/spark3d/examples) and runners (`run_*.sh`) in the root folder of the repo.
+We also include [examples](https://github.com/astrolabsoftware/spark3D/tree/master/src/main/scala/com/spark3d/examples) and runners (`run_*.sh`) in the root folder of the repo.
 You might have to modify those scripts with your environment.

--- a/docs/02_introduction.md
+++ b/docs/02_introduction.md
@@ -119,7 +119,7 @@ to be directly injected into the HDFS infrastructure, so as to develop a Spark b
 Therefore we will have to develop low level Reader/Writer services,
 to support direct access to FITS data, without copy nor conversion needs.
 To tackle this challenge, we started a new project called
-[spark-fits](https://github.com/theastrolab/spark-fits), which provides a
+[spark-fits](https://github.com/astrolabsoftware/spark-fits), which provides a
 Spark connector for FITS data, and a Scala library for manipulating FITS file.
 
 We plan to release more in the future (HDF5 and ROOT on the TODO list!), and you are welcome to submit requests for specific data sources!

--- a/docs/03_partitioning.md
+++ b/docs/03_partitioning.md
@@ -17,7 +17,7 @@ Unfortunately, re-partitioning the space involves potentially large shuffle betw
 
 There are currently 2 partitioning implemented in the library:
 
-- **Onion Partitioning:** See [here](https://github.com/theastrolab/spark3D/issues/11) for a description. This is mostly intented for processing astrophysical data as it partitions the space in 3D shells along the radial axis, with the possibility of projecting into 2D shells (and then partitioning the shells using Healpix).
+- **Onion Partitioning:** See [here](https://github.com/astrolabsoftware/spark3D/issues/11) for a description. This is mostly intented for processing astrophysical data as it partitions the space in 3D shells along the radial axis, with the possibility of projecting into 2D shells (and then partitioning the shells using Healpix).
 - **Octree:** An octree extends a quadtree by using three orthogonal splitting planes to subdivide a tile into eight children. Like quadtrees, 3D Tiles allows variations to octrees such as non-uniform subdivision, tight bounding volumes, and overlapping children.
 
 ### Onion Partitioning

--- a/docs/04_query.md
+++ b/docs/04_query.md
@@ -149,7 +149,7 @@ Cross match based on center distance (A, B, BxA)    |Cross match based on center
 :-------------------------:|:-------------------------:
 ![raw]({{ "/assets/images/CcrossmatchAxB.png" | absolute_url }}) | ![raw]({{ "/assets/images/CcrossmatchAxBOnly.png" | absolute_url }})
 
-For more details on the cross-match, see the following [notebook](https://github.com/theastrolab/spark3D/blob/master/examples/jupyter/CrossMatch.ipynb).
+For more details on the cross-match, see the following [notebook](https://github.com/astrolabsoftware/spark3D/blob/master/examples/jupyter/CrossMatch.ipynb).
 
 ## Neighbour search
 

--- a/docs/05_visualization.md
+++ b/docs/05_visualization.md
@@ -11,6 +11,6 @@ For the moment, our visualisation is done thanks to [smile](https://github.com/h
 
 | Raw data set | Re-partitioned data set |
 |:---------:|:---------:|
-| ![raw](https://github.com/theastrolab/spark3D/blob/master/examples/jupyter/images/myOnionFigRaw.png) | ![repartitioning](https://github.com/theastrolab/spark3D/blob/master/examples/jupyter/images/myOnionFig.png)|
+| ![raw](https://github.com/astrolabsoftware/spark3D/blob/master/examples/jupyter/images/myOnionFigRaw.png) | ![repartitioning](https://github.com/astrolabsoftware/spark3D/blob/master/examples/jupyter/images/myOnionFig.png)|
 
 If you have better tools or want to develop something specific, let us know!

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,9 +19,9 @@ title                    : "spark3D"
 title_separator          : "-"
 name                     : "spark3D"
 description              : "Apache Spark extension for processing large-scale 3D data sets, such as astrophysical or high energy physics data."
-url                      : https://theastrolab.github.io
+url                      : https://astrolabsoftware.github.io
 baseurl                  : /spark3D
-repository               : "theastrolab/spark3D"
+repository               : "astrolabsoftware/spark3D"
 teaser                   :
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -7,7 +7,7 @@ header:
   cta_label: "<i class='fas fa-download'></i> Install Now"
   cta_url: "/docs/installation/"
   caption:
-excerpt: 'Spark extension for processing large-scale 3D data sets: Astrophysics, High Energy Physics, Meteorology, ...<br /> <small><a href="https://github.com/theastrolab/spark3D/releases/tag/0.1.1">Latest release v0.1.1</a></small><br /><br /> {::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=theastrolab&repo=spark3D&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=theastrolab&repo=spark3D&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
+excerpt: 'Spark extension for processing large-scale 3D data sets: Astrophysics, High Energy Physics, Meteorology, ...<br /> <small><a href="https://github.com/astrolabsoftware/spark3D/releases/tag/0.1.1">Latest release v0.1.1</a></small><br /><br /> {::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark3D&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark3D&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
 feature_row:
   - image_path:
     alt:

--- a/docs/about.md
+++ b/docs/about.md
@@ -24,7 +24,7 @@ which were hitherto too costly to be processed efficiently.
 With the recent development of fast and general engine such as
 [Apache Spark](http://spark.apache.org), taking advantage of
 distributed systems, we enter in a new area of possibilities.
-[spark3D](https://github.com/theastrolab/spark3D) extends Apache Spark to
+[spark3D](https://github.com/astrolabsoftware/spark3D) extends Apache Spark to
 efficiently load, process, and analyze large-scale 3D spatial data sets across machines.
 
 ## Goals of spark3D


### PR DESCRIPTION
Organisation name changes from theastrolab to astrolabsoftware (https://astrolabsoftware.github.io/)