### PR TITLE
KNN unique implementation

### DIFF
--- a/src/main/scala/com/spark3d/spatialOperator/SpatialQuery.scala
+++ b/src/main/scala/com/spark3d/spatialOperator/SpatialQuery.scala
@@ -39,7 +39,6 @@ object SpatialQuery {
     * @return knn
     */
   def KNN[T <: Shape3D: ClassTag](queryObject: T, rdd: RDD[T], k: Int, unique: Boolean = false): List[T] = {
-//    val knn = rdd.takeOrdered(k)(new GeometryObjectComparator[B](queryObject.center))
     val knn = takeOrdered[T](rdd, k, queryObject, unique)(new GeometryObjectComparator[T](queryObject.center))
     knn.toList
   }

--- a/src/main/scala/com/spark3d/spatialOperator/SpatialQuery.scala
+++ b/src/main/scala/com/spark3d/spatialOperator/SpatialQuery.scala
@@ -18,11 +18,12 @@ package com.astrolabsoftware.spark3d.spatialOperator
 
 import com.astrolabsoftware.spark3d.geometryObjects.Shape3D.Shape3D
 import com.astrolabsoftware.spark3d.utils.GeometryObjectComparator
-import org.apache.spark.rdd.RDD
+import com.astrolabsoftware.spark3d.utils.Utils.takeOrdered
 import com.astrolabsoftware.spark3d.spatialPartitioning._
 
-import scala.collection.mutable
-import scala.collection.mutable.{HashSet, ListBuffer, PriorityQueue}
+import org.apache.spark.rdd.RDD
+
+import scala.collection.mutable.{HashSet, ListBuffer}
 import scala.reflect.ClassTag
 import scala.util.control.Breaks._
 

--- a/src/main/scala/com/spark3d/utils/BoundedUniquePriorityQueue.scala
+++ b/src/main/scala/com/spark3d/utils/BoundedUniquePriorityQueue.scala
@@ -20,14 +20,27 @@ import java.io.Serializable
 import com.astrolabsoftware.spark3d.geometryObjects.Shape3D.Shape3D
 
 import scala.collection.generic.Growable
-import collection.mutable.PriorityQueue
 import scala.collection.mutable
 
+import collection.mutable.PriorityQueue
+
+/**
+  * A wrapper on top of the normal priority queue, so that it is bounded by a given capacity
+  * (in case of overflow, replace the element based on the priority defined) and at the same time
+  * ensure that the priority queue contains only unique elements.
+  *
+  * @param maxSize
+  * @param ord
+  * @tparam A
+  */
 class BoundedUniquePriorityQueue[A <: Shape3D](maxSize: Int)(implicit ord: Ordering[A])
   extends Iterable[A] with Growable[A] with Serializable {
 
+  // underlying base priority queue
   private val underlying = new PriorityQueue[A]()(ord)
 
+  // HashSet of elements contained in the priority queue used to ensure uniqueness of the elements
+  // in the priority queue.
   private val containedElements = new mutable.HashSet[Int]()
 
   override def iterator: Iterator[A] = underlying.iterator
@@ -41,6 +54,7 @@ class BoundedUniquePriorityQueue[A <: Shape3D](maxSize: Int)(implicit ord: Order
 
   override def +=(elem: A): this.type = {
     val elementHash = elem.center.getCoordinate.hashCode
+    // check if element to be inserted is unique or not
     if (!containedElements.contains(elementHash)) {
       if (size < maxSize) {
         underlying.enqueue(elem)

--- a/src/main/scala/com/spark3d/utils/Utils.scala
+++ b/src/main/scala/com/spark3d/utils/Utils.scala
@@ -16,6 +16,13 @@
 package com.astrolabsoftware.spark3d.utils
 
 import com.astrolabsoftware.spark3d.geometryObjects._
+import com.astrolabsoftware.spark3d.geometryObjects.Shape3D.Shape3D
+import com.google.common.collect.{Ordering => GuavaOrdering}
+
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+import scala.collection.JavaConverters._
 
 object Utils {
 
@@ -101,5 +108,47 @@ object Utils {
     } else {
       ra
     }
+  }
+
+  /**
+    * Custom takeOrdered function to take unique top k elements from the RDD based on the priority
+    * of the elements relative to the queryObject defined by the custom Ordering.
+    * In case, the unique elements are not needed, fallback to using the RDD's takeOrdered function.
+    *
+    * @param rdd RDD from which the elements are to be taken
+    * @param num number of elements to be taken from the RDD
+    * @param queryObject elements relative to which the priority is to be defined
+    * @param unique true/false based on whether unique elements should be returned or not
+    * @param ord custom Ordering based on which the top k elements are to be taken
+    * @return array of top k elements based on the Ordering relative to the queryObject from the input RDD
+    */
+  def takeOrdered[T <: Shape3D: ClassTag](rdd: RDD[T], num: Int, queryObject: T, unique: Boolean = false)(ord: Ordering[T]): Array[T] = {
+    if (unique) {
+      if (num == 0) {
+        Array.empty
+      } else {
+        val mapRDDs = rdd.mapPartitions { items =>
+          val queue = new BoundedUniquePriorityQueue[T](num)(ord.reverse)
+          queue ++= takeOrdered(items, num)(ord)
+          Iterator.single(queue)
+        }
+        if (mapRDDs.partitions.length == 0) {
+          return Array.empty
+        } else {
+          return mapRDDs.reduce { (queue1, queue2) =>
+            queue1 ++= queue2
+            queue1
+          }.toArray.sorted(ord)
+        }
+      }
+    }
+    return rdd.takeOrdered(num)(new GeometryObjectComparator[T](queryObject.center))
+  }
+
+  private def takeOrdered[T](input: Iterator[T], num: Int)(implicit ord: Ordering[T]): Iterator[T] = {
+    val ordering = new GuavaOrdering[T] {
+      override def compare(l: T, r: T): Int = ord.compare(l, r)
+    }
+    ordering.leastOf(input.asJava, num).iterator.asScala
   }
 }

--- a/src/test/scala/com/spark3d/spatialOperator/SpatialQueryTest.scala
+++ b/src/test/scala/com/spark3d/spatialOperator/SpatialQueryTest.scala
@@ -52,17 +52,17 @@ class SpatialQueryTest extends FunSuite with BeforeAndAfterAll {
   }
 
   val csv_man = "src/test/resources/cartesian_spheres_manual_knn.csv"
-  val fn_fits = "src/test/resources/cartesian_points.fits"
+  val fn_fits = "src/test/resources/cartesian_spheres.fits"
 
-  test("Can you find the unique K nearest neighbours?") {
+  test("Can you find the K nearest neighbours?") {
     val pointRDD = new Point3DRDD(spark, fn_fits, 1, "x,y,z", false)
     val queryObject = new Point3D(0.2, 0.2, 0.2, false)
     // using Octree partitioning
     val pointRDDPart = pointRDD.spatialPartitioning(GridType.OCTREE, 100)
-    val knn = SpatialQuery.KNN(queryObject, pointRDDPart, 5000)
+    val knn = SpatialQuery.KNN(queryObject, pointRDDPart, 5000, true)
     val knnEff = SpatialQuery.KNNEfficient(queryObject, pointRDDPart, 5000)
 
-//    assert(knn.map(x=>x.center.getCoordinate).distinct.size == 5000)
+    assert(knn.map(x=>x.center.getCoordinate).distinct.size == 5000)
 //    assert(knnEff.map(x=>x.center.getCoordinate).distinct.size == 5000)
 
     // using Onion partitioning


### PR DESCRIPTION
A priority queue based implementation of the KNN which return k unique elements.
Steps - 
 1. Find k unique nearest neighbors in each of the partition.
 2. Merge the lists from all partitions into a single list of size k based on the ordering. 
