### PR TITLE
fix for elements missing after repartitioning RDD with Octree Partitioner

### DIFF
--- a/src/main/scala/com/spark3d/geometryObjects/BoxEnvelope.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/BoxEnvelope.scala
@@ -264,6 +264,32 @@ class BoxEnvelope private(
   }
 
   /**
+    * Expand cube Envelope outwards by given distance along the all three dimensions.
+    *
+    * @param delta
+    */
+  def expandOutwards(delta: Double): Unit = {
+    expandOutwards(delta, delta, delta)
+  }
+
+  /**
+    * Expand cube Envelope outwards by given distances along the three dimension.
+    *
+    * @param deltaX
+    * @param deltaY
+    * @param deltaZ
+    */
+  def expandOutwards(deltaX: Double, deltaY: Double, deltaZ: Double): Unit = {
+    if (isNull) {
+      return
+    }
+
+    maxX += deltaX
+    maxY += deltaY
+    maxZ += deltaZ
+  }
+
+  /**
     * Expand cube Envelope by given distances along the three dimension.
     *
     * @param deltaX the distance to expand the cube Envelope along the the X axis

--- a/src/main/scala/com/spark3d/spatial3DRDD/Shape3DRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/Shape3DRDD.scala
@@ -193,6 +193,11 @@ abstract class Shape3DRDD[T<:Shape3D] extends Serializable {
     // set it to null
     bx.setToNull
 
-    rawRDD.aggregate(bx)(combOp, seqOp)
+    val dataBoundary = rawRDD.aggregate(bx)(combOp, seqOp)
+
+    // expand the boundary to also Include the elements at the border
+    dataBoundary.expandOutwards(0.001)
+
+    dataBoundary
   }
 }

--- a/src/test/scala/com/spark3d/spatial3DRDD/SphereRDDTest.scala
+++ b/src/test/scala/com/spark3d/spatial3DRDD/SphereRDDTest.scala
@@ -73,7 +73,7 @@ class SphereRDDTest extends FunSuite with BeforeAndAfterAll {
     val sphereRDD = new SphereRDD(spark, fn_csv_manual,"x,y,z,radius", false, "csv", options)
 
     // check the data boundary
-    val dataBoundary = BoxEnvelope.apply(0.0, 4.0, 0.0, 4.0, 0.0, 4.0)
+    val dataBoundary = BoxEnvelope.apply(0.0, 4.001, 0.0, 4.001, 0.0, 4.001)
     assert(sphereRDD.getDataEnvelope.isEqual(dataBoundary))
 
     // replicating the Shape3DRDD code here to verify the placeObject
@@ -99,7 +99,7 @@ class SphereRDDTest extends FunSuite with BeforeAndAfterAll {
       iterator.next
     }
     assert(count == 1)
-    iterator = partitioner.placeObject(new ShellEnvelope(1.0,1.0,1.0,false,1.0))
+    iterator = partitioner.placeObject(new ShellEnvelope(1.0,1.0,1.0,false,1.1))
     count = 0
     while(iterator.hasNext) {
       count += 1


### PR DESCRIPTION
Expanding the boundary of the data set by a delta (0.001) now so that the elements at the edge of the boundary are also included. This was an issue because we have modified the Geometric operation contains from,
```
def contains(ele: BoxEnvelope): Boolean = {
    ele.minX >= minX && ele.maxX <= maxX  &&
     //similary for Y and Z axis
```
to 
```
def contains(ele: BoxEnvelope): Boolean = {
    ele.minX >= minX && ele.maxX < maxX  &&
     //similary for Y and Z axis
```
Hence, to resolve issue exanding the data boundary envelope outwards by a delta.
