### PR TITLE
Allow user to cache the rawRDD while loading data to speed-up re-partitioning.

### DIFF
--- a/docs/02_introduction.md
+++ b/docs/02_introduction.md
@@ -75,10 +75,10 @@ import com.astrolabsoftware.spark3d.spatial3DRDD.Point3DRDD
 // according to `colnames`.
 val pointRDD = new Point3DRDD(spark: SparkSession, filename: String, colnames: String,
   isSpherical: Boolean, format: String, options: Map[String, String],
-  storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK)
+  storageLevel: StorageLevel = StorageLevel.NONE)
 ```
 
-Since we typically need to operate multiple times on the rawRDD (e.g. gather statistics), you can control the persistence on the rawRDD (default is StorageLevel.MEMORY_AND_DISK, aka `.cache()`) to reduce the execution time.
+Since we typically need to operate multiple times on the rawRDD (e.g. gather statistics), you can control the persistence on the rawRDD (default is `StorageLevel.NONE`, but you are strongly advised to choose `StorageLevel.MEMORY_ONLY` aka `.cache()` if you have enough memory) to reduce the execution time.
 `format` and `options` control the correct reading of your data.
 
 * `format` is the name of the data source as registered in Spark. For example: `csv`, `json`, `org.dianahep.sparkroot`, ... For Spark built-in see [here](https://github.com/apache/spark/blob/301bff70637983426d76b106b7c659c1f28ed7bf/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala#L560).
@@ -139,7 +139,7 @@ import com.astrolabsoftware.spark3d.spatial3DRDD.SphereRDD
 // according to `colnames`.
 val sphereRDD = new SphereRDD(spark: SparkSession, filename: String, colnames: String,
   isSpherical: Boolean, format: String, options: Map[String, String],
-  storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK)
+  storageLevel: StorageLevel = StorageLevel.NONE)
 ```
 
 The resulting RDD is a `RDD[ShellEnvelope]`.

--- a/docs/02_introduction.md
+++ b/docs/02_introduction.md
@@ -74,9 +74,11 @@ import com.astrolabsoftware.spark3d.spatial3DRDD.Point3DRDD
 // Order of columns in the file does not matter, as they will be re-aranged
 // according to `colnames`.
 val pointRDD = new Point3DRDD(spark: SparkSession, filename: String, colnames: String,
-  isSpherical: Boolean, format: String, options: Map[String, String])
+  isSpherical: Boolean, format: String, options: Map[String, String],
+  storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY)
 ```
 
+Since we typically need to operate multiple times on the rawRDD (e.g. gather statistics), you can control the persistence on the rawRDD (default is StorageLevel.MEMORY_ONLY, aka `.cache()`) to reduce the execution time.
 `format` and `options` control the correct reading of your data.
 
 * `format` is the name of the data source as registered in Spark. For example: `csv`, `json`, `org.dianahep.sparkroot`, ... For Spark built-in see [here](https://github.com/apache/spark/blob/301bff70637983426d76b106b7c659c1f28ed7bf/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala#L560).
@@ -136,7 +138,8 @@ import com.astrolabsoftware.spark3d.spatial3DRDD.SphereRDD
 // Order of columns in the file does not matter, as they will be re-aranged
 // according to `colnames`.
 val sphereRDD = new SphereRDD(spark: SparkSession, filename: String, colnames: String,
-  isSpherical: Boolean, format: String, options: Map[String, String])
+  isSpherical: Boolean, format: String, options: Map[String, String],
+  storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY)
 ```
 
 The resulting RDD is a `RDD[ShellEnvelope]`.

--- a/docs/02_introduction.md
+++ b/docs/02_introduction.md
@@ -75,10 +75,10 @@ import com.astrolabsoftware.spark3d.spatial3DRDD.Point3DRDD
 // according to `colnames`.
 val pointRDD = new Point3DRDD(spark: SparkSession, filename: String, colnames: String,
   isSpherical: Boolean, format: String, options: Map[String, String],
-  storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY)
+  storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK)
 ```
 
-Since we typically need to operate multiple times on the rawRDD (e.g. gather statistics), you can control the persistence on the rawRDD (default is StorageLevel.MEMORY_ONLY, aka `.cache()`) to reduce the execution time.
+Since we typically need to operate multiple times on the rawRDD (e.g. gather statistics), you can control the persistence on the rawRDD (default is StorageLevel.MEMORY_AND_DISK, aka `.cache()`) to reduce the execution time.
 `format` and `options` control the correct reading of your data.
 
 * `format` is the name of the data source as registered in Spark. For example: `csv`, `json`, `org.dianahep.sparkroot`, ... For Spark built-in see [here](https://github.com/apache/spark/blob/301bff70637983426d76b106b7c659c1f28ed7bf/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala#L560).
@@ -139,7 +139,7 @@ import com.astrolabsoftware.spark3d.spatial3DRDD.SphereRDD
 // according to `colnames`.
 val sphereRDD = new SphereRDD(spark: SparkSession, filename: String, colnames: String,
   isSpherical: Boolean, format: String, options: Map[String, String],
-  storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY)
+  storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK)
 ```
 
 The resulting RDD is a `RDD[ShellEnvelope]`.

--- a/docs/03_partitioning.md
+++ b/docs/03_partitioning.md
@@ -44,7 +44,7 @@ val options = Map("hdu" -> "1")
 
 // Load the data and cache the rawRDD to speed-up the re-partitioning
 val pointRDD = new Point3DRDD(
-	spark, fn, columns, spherical, format, options, StorageLevel.MEMORY_ONLY
+	spark, fn, columns, spherical, format, options, StorageLevel.MEMORY_AND_DISK
 )
 
 // nPart is the wanted number of partitions. Default is pointRDD partition number.
@@ -78,7 +78,7 @@ val options = Map("hdu" -> "1")
 
 // Load the data and cache the rawRDD to speed-up the re-partitioning
 val sphereRDD = new SphereRDD(
-	spark, fn, columns, spherical, format, options, StorageLevel.MEMORY_ONLY
+	spark, fn, columns, spherical, format, options, StorageLevel.MEMORY_AND_DISK
 )
 
 // nPart is the wanted number of partitions (floored to a power of 8).

--- a/docs/03_partitioning.md
+++ b/docs/03_partitioning.md
@@ -44,7 +44,7 @@ val options = Map("hdu" -> "1")
 
 // Load the data and cache the rawRDD to speed-up the re-partitioning
 val pointRDD = new Point3DRDD(
-	spark, fn, columns, spherical, format, options, StorageLevel.MEMORY_AND_DISK
+	spark, fn, columns, spherical, format, options, StorageLevel.MEMORY_ONLY
 )
 
 // nPart is the wanted number of partitions. Default is pointRDD partition number.
@@ -78,7 +78,7 @@ val options = Map("hdu" -> "1")
 
 // Load the data and cache the rawRDD to speed-up the re-partitioning
 val sphereRDD = new SphereRDD(
-	spark, fn, columns, spherical, format, options, StorageLevel.MEMORY_AND_DISK
+	spark, fn, columns, spherical, format, options, StorageLevel.MEMORY_ONLY
 )
 
 // nPart is the wanted number of partitions (floored to a power of 8).

--- a/src/main/scala/com/spark3d/examples/Partitioning.scala
+++ b/src/main/scala/com/spark3d/examples/Partitioning.scala
@@ -21,6 +21,7 @@ import com.astrolabsoftware.spark3d.spatial3DRDD._
 import com.astrolabsoftware.spark3d.utils.GridType
 
 // Spark lib
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 
@@ -64,7 +65,9 @@ object Partitioning {
 
     // Load the data
     val options = Map("hdu" -> hdu)
-    val pRDD = new Point3DRDD(spark, fn_fits, columns, isSpherical, "fits", options)
+    val pRDD = new Point3DRDD(
+      spark, fn_fits, columns, isSpherical, "fits", options, StorageLevel.MEMORY_ONLY
+    )
 
     // Partition it
     val rdd = mode match {

--- a/src/main/scala/com/spark3d/examples/Partitioning.scala
+++ b/src/main/scala/com/spark3d/examples/Partitioning.scala
@@ -68,7 +68,7 @@ object Partitioning {
 
     // Partition it
     val rdd = mode match {
-        case "nopart" => pRDD.rawRDD.cache()
+        case "nopart" => pRDD.rawRDD
         case "octree" => pRDD.spatialPartitioning(GridType.OCTREE).cache()
         case "onion" => pRDD.spatialPartitioning(GridType.LINEARONIONGRID).cache()
         case _ => throw new AssertionError("Choose between nopart, onion, or octree for the partitioning.")

--- a/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
@@ -77,7 +77,7 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
     */
   def this(spark : SparkSession, filename : String, colnames : String, isSpherical: Boolean,
       format: String, options: Map[String, String] = Map("" -> ""),
-      storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK) {
+      storageLevel: StorageLevel = StorageLevel.NONE) {
     this(
       Point3DRDDFromV2(
         spark, filename, colnames, isSpherical, format, options

--- a/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
@@ -68,7 +68,7 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
     * @param options : (Map[String, String])
     *   Options to pass to the DataFrameReader. Default is no options.
     * @param storageLevel : (StorageLevel)
-    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_ONLY.
+    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_AND_DISK.
     *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
     *   for more information.
     * @return (RDD[Point3D])
@@ -77,7 +77,7 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
     */
   def this(spark : SparkSession, filename : String, colnames : String, isSpherical: Boolean,
       format: String, options: Map[String, String] = Map("" -> ""),
-      storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY) {
+      storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK) {
     this(
       Point3DRDDFromV2(
         spark, filename, colnames, isSpherical, format, options
@@ -100,7 +100,7 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
   *   center are (r, theta, phi).
   *   Otherwise, it assumes cartesian coordinates (x, y, z).
   * @param storageLevel : (StorageLevel)
-  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_ONLY.
+  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_AND_DISK.
   *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
   *   for more information.
   *

--- a/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
@@ -18,12 +18,13 @@ package com.astrolabsoftware.spark3d.spatial3DRDD
 import com.astrolabsoftware.spark3d.geometryObjects._
 import com.astrolabsoftware.spark3d.spatial3DRDD.Loader._
 
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.col
 import org.apache.spark.rdd.RDD
 
 
-class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean) extends Shape3DRDD[Point3D] {
+class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageLevel: StorageLevel) extends Shape3DRDD[Point3D] {
 
   /**
     * Construct a RDD[Point3D] from whatever data source registered in Spark.
@@ -71,19 +72,19 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean) extends 
     *
     */
   def this(spark : SparkSession, filename : String, colnames : String, isSpherical: Boolean,
-      format: String, options: Map[String, String] = Map("" -> "")) {
-    this(Point3DRDDFromV2(spark, filename, colnames, isSpherical, format, options), isSpherical)
+      format: String, options: Map[String, String] = Map("" -> ""), storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY_SER) {
+    this(Point3DRDDFromV2(spark, filename, colnames, isSpherical, format, options), isSpherical, storageLevel)
   }
 
   // Raw partitioned RDD
-  override val rawRDD = rdd
+  override val rawRDD = rdd.persist(storageLevel)
 }
 
 /**
   * Handle point3DRDD.
   */
 object Point3DRDD {
-  def apply(rdd : RDD[Point3D], isSpherical: Boolean): Point3DRDD = {
-    new Point3DRDD(rdd, isSpherical)
+  def apply(rdd : RDD[Point3D], isSpherical: Boolean, storageLevel: StorageLevel): Point3DRDD = {
+    new Point3DRDD(rdd, isSpherical, storageLevel)
   }
 }

--- a/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
@@ -67,13 +67,22 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
     *     - gov.llnl.spark.hdf or hdf5
     * @param options : (Map[String, String])
     *   Options to pass to the DataFrameReader. Default is no options.
+    * @param storageLevel : (StorageLevel)
+    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_ONLY.
+    *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
+    *   for more information.
     * @return (RDD[Point3D])
     *
     *
     */
   def this(spark : SparkSession, filename : String, colnames : String, isSpherical: Boolean,
-      format: String, options: Map[String, String] = Map("" -> ""), storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY) {
-    this(Point3DRDDFromV2(spark, filename, colnames, isSpherical, format, options), isSpherical, storageLevel)
+      format: String, options: Map[String, String] = Map("" -> ""),
+      storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY) {
+    this(
+      Point3DRDDFromV2(
+        spark, filename, colnames, isSpherical, format, options
+      ), isSpherical, storageLevel
+    )
   }
 
   // Raw partitioned RDD
@@ -82,7 +91,19 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
 }
 
 /**
-  * Handle point3DRDD.
+  * Construct a Point3DRDD from a RDD[Point3D]
+  *
+  * @param rdd : (RDD[Point3D])
+  *   RDD whose elements are Point3D instances.
+  * @param isSpherical : (Boolean)
+  *   If true, it assumes that the coordinates of the points
+  *   center are (r, theta, phi).
+  *   Otherwise, it assumes cartesian coordinates (x, y, z).
+  * @param storageLevel : (StorageLevel)
+  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_ONLY.
+  *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
+  *   for more information.
+  *
   */
 object Point3DRDD {
   def apply(rdd : RDD[Point3D], isSpherical: Boolean, storageLevel: StorageLevel): Point3DRDD = {

--- a/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
@@ -72,12 +72,13 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
     *
     */
   def this(spark : SparkSession, filename : String, colnames : String, isSpherical: Boolean,
-      format: String, options: Map[String, String] = Map("" -> ""), storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY_SER) {
+      format: String, options: Map[String, String] = Map("" -> ""), storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY) {
     this(Point3DRDDFromV2(spark, filename, colnames, isSpherical, format, options), isSpherical, storageLevel)
   }
 
   // Raw partitioned RDD
-  override val rawRDD = rdd.persist(storageLevel)
+  override val rawRDD = rdd
+  rawRDD.persist(storageLevel)
 }
 
 /**

--- a/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/Point3DRDD.scala
@@ -68,7 +68,7 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
     * @param options : (Map[String, String])
     *   Options to pass to the DataFrameReader. Default is no options.
     * @param storageLevel : (StorageLevel)
-    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_AND_DISK.
+    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.NONE.
     *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
     *   for more information.
     * @return (RDD[Point3D])
@@ -100,7 +100,7 @@ class Point3DRDD(rdd : RDD[Point3D], override val isSpherical: Boolean, storageL
   *   center are (r, theta, phi).
   *   Otherwise, it assumes cartesian coordinates (x, y, z).
   * @param storageLevel : (StorageLevel)
-  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_AND_DISK.
+  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.NONE.
   *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
   *   for more information.
   *

--- a/src/main/scala/com/spark3d/spatial3DRDD/Shape3DRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/Shape3DRDD.scala
@@ -112,8 +112,8 @@ abstract class Shape3DRDD[T<:Shape3D] extends Serializable {
       }
       case GridType.OCTREE => {
         // taking 20% of the data as a sample
-        val dataCount = rawRDD.count //20000
-        val sampleSize = getSampleSize(dataCount, numPartitions) //
+        val dataCount = rawRDD.count
+        val sampleSize = getSampleSize(dataCount, numPartitions)
         val samples = rawRDD.takeSample(false, sampleSize,
             new Random(dataCount).nextInt(dataCount.asInstanceOf[Int])).toList.map(x => x.getEnvelope)
         // see https://github.com/JulienPeloton/spark3D/issues/37

--- a/src/main/scala/com/spark3d/spatial3DRDD/SphereRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/SphereRDD.scala
@@ -67,7 +67,7 @@ class SphereRDD(rdd : RDD[ShellEnvelope],
     * @param options : (Map[String, String])
     *   Options to pass to the DataFrameReader. Default is no options.
     * @param storageLevel : (StorageLevel)
-    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_ONLY.
+    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_AND_DISK.
     *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
     *   for more information.
     * @return (RDD[ShellEnvelope])
@@ -76,7 +76,7 @@ class SphereRDD(rdd : RDD[ShellEnvelope],
   def this(spark : SparkSession, filename : String,
       colnames : String, isSpherical: Boolean,
       format: String, options: Map[String, String] = Map("" -> ""),
-      storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY) {
+      storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK) {
     this(SphereRDDFromV2(spark, filename, colnames, isSpherical, format, options),
       isSpherical, storageLevel
     )
@@ -97,7 +97,7 @@ class SphereRDD(rdd : RDD[ShellEnvelope],
   *   center are (r, theta, phi).
   *   Otherwise, it assumes cartesian coordinates (x, y, z).
   * @param storageLevel : (StorageLevel)
-  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_ONLY.
+  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_AND_DISK.
   *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
   *   for more information.
   *

--- a/src/main/scala/com/spark3d/spatial3DRDD/SphereRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/SphereRDD.scala
@@ -76,7 +76,7 @@ class SphereRDD(rdd : RDD[ShellEnvelope],
   def this(spark : SparkSession, filename : String,
       colnames : String, isSpherical: Boolean,
       format: String, options: Map[String, String] = Map("" -> ""),
-      storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK) {
+      storageLevel: StorageLevel = StorageLevel.NONE) {
     this(SphereRDDFromV2(spark, filename, colnames, isSpherical, format, options),
       isSpherical, storageLevel
     )

--- a/src/main/scala/com/spark3d/spatial3DRDD/SphereRDD.scala
+++ b/src/main/scala/com/spark3d/spatial3DRDD/SphereRDD.scala
@@ -67,7 +67,7 @@ class SphereRDD(rdd : RDD[ShellEnvelope],
     * @param options : (Map[String, String])
     *   Options to pass to the DataFrameReader. Default is no options.
     * @param storageLevel : (StorageLevel)
-    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_AND_DISK.
+    *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.NONE.
     *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
     *   for more information.
     * @return (RDD[ShellEnvelope])
@@ -97,7 +97,7 @@ class SphereRDD(rdd : RDD[ShellEnvelope],
   *   center are (r, theta, phi).
   *   Otherwise, it assumes cartesian coordinates (x, y, z).
   * @param storageLevel : (StorageLevel)
-  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.MEMORY_AND_DISK.
+  *   Storage level for the raw RDD (unpartitioned). Default is StorageLevel.NONE.
   *   See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence
   *   for more information.
   *

--- a/src/test/scala/com/spark3d/spatial3DRDD/Point3DRDDTest.scala
+++ b/src/test/scala/com/spark3d/spatial3DRDD/Point3DRDDTest.scala
@@ -22,6 +22,7 @@ import com.astrolabsoftware.spark3d.utils.GridType
 import com.astrolabsoftware.spark3d.spatial3DRDD._
 import com.astrolabsoftware.spark3d.spatialPartitioning.SpatialPartitioner
 
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
@@ -98,7 +99,7 @@ class Point3DRDDTest extends FunSuite with BeforeAndAfterAll {
 
     val rdd = pointRDD.rawRDD
 
-    val newRDD = new Point3DRDD(rdd, pointRDD.isSpherical)
+    val newRDD = new Point3DRDD(rdd, pointRDD.isSpherical, StorageLevel.MEMORY_ONLY)
 
     assert(newRDD.isInstanceOf[Shape3DRDD[Point3D]])
   }

--- a/src/test/scala/com/spark3d/spatial3DRDD/SphereRDDTest.scala
+++ b/src/test/scala/com/spark3d/spatial3DRDD/SphereRDDTest.scala
@@ -20,11 +20,11 @@ import com.astrolabsoftware.spark3d.geometryObjects.{BoxEnvelope, ShellEnvelope}
 import com.astrolabsoftware.spark3d.utils.GridType
 import com.astrolabsoftware.spark3d.spatial3DRDD._
 import com.astrolabsoftware.spark3d.spatialPartitioning.{Octree, OctreePartitioner, OctreePartitioning, SpatialPartitioner}
+
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.functions._
-import org.apache.log4j.Level
-import org.apache.log4j.Logger
 
 import scala.math.{ceil, floor, log, pow}
 
@@ -127,7 +127,7 @@ class SphereRDDTest extends FunSuite with BeforeAndAfterAll {
     val options = Map("header" -> "true")
     val pointRDD = new SphereRDD(spark, fn_csv, "x,y,z,radius", false, "csv", options)
 
-    val newRDD = new SphereRDD(pointRDD.rawRDD, pointRDD.isSpherical)
+    val newRDD = new SphereRDD(pointRDD.rawRDD, pointRDD.isSpherical, StorageLevel.MEMORY_ONLY)
 
     assert(newRDD.isInstanceOf[Shape3DRDD[ShellEnvelope]])
   }


### PR DESCRIPTION
When re-partitioning, we typically needs to operate on the rawRDD (e.g. gather statistics) several times, so I've added persistence on the rawRDD (default is StorageLevel.MEMORY_ONLY) to reduce the execution time. Here is a summary on re-partitioning 10 million Point3D:

| | no repartition | Onion | Octree |
|:--:|:--:|:--:|:--:|
| previous time (s) | 15 | 70 | 96 |
| new time (s) | 15 | 50 | 57|

Octree re-partitioning benefits a lot from this as we have to perform `count`, `takeSample` and `aggregate` prior to the re-partitioning. 
