### PR TITLE
Tools to perform live 3D RDD visualisation

### DIFF
--- a/pyspark3d/__init__.py
+++ b/pyspark3d/__init__.py
@@ -156,7 +156,7 @@ def get_spark_session(
     <class 'pyspark.sql.session.SparkSession'>
     """
     # Grab the user conf
-    conf = pyspark3d_conf("local", "test", dicconf)
+    conf = pyspark3d_conf(master, appname, dicconf)
 
     # Instantiate a spark session
     spark = SparkSession\

--- a/pyspark3d/converters.py
+++ b/pyspark3d/converters.py
@@ -257,7 +257,7 @@ if __name__ == "__main__":
 
     # Activate the SparkContext for the test suite
     dic = load_user_conf()
-    conf = pyspark3d_conf("local", "test", dic)
+    conf = pyspark3d_conf("local[*]", "test", dic)
     sc = SparkContext.getOrCreate(conf=conf)
 
     # Numpy introduced non-backward compatible change from v1.14.

--- a/pyspark3d/visualisation.py
+++ b/pyspark3d/visualisation.py
@@ -1,0 +1,261 @@
+# Copyright 2018 Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from typing import Iterator, Any, Callable
+
+from py4j.java_gateway import JavaObject
+
+from pyspark3d import load_from_jvm
+from pyspark3d.converters import scala2python
+
+from pyspark.mllib.common import _java2py
+from pyspark import RDD
+
+class CollapseFunctions():
+    """ Set of functions to create a representation of the data.
+    The idea is to reduce the size of the dataset while keeping desired
+    features (e.g. clustering).
+
+    We give as an example two simple examples dealing with the clustering:
+    - mean (1-means)
+    - k-means
+
+    The reduction is done at the level of the Spark partition (Iterator).
+
+    """
+
+    def mean(self, partition: Iterator) -> (list, int):
+        """Compute the centroid of the partition.
+        It can be viewed as a k-means for k=1.
+
+        Parameters
+        ----------
+        partition : Iterator
+            Iterator over the elements of the Spark partition.
+
+        Returns
+        -------
+        (list, int)
+            Yield tuple with the centroid and the total number of points
+            in the partition. If the partition is empty, return (None, 0).
+
+        Examples
+        -------
+        List of coordinates (can be 2D, 3D, ..., nD)
+        >>> mylist = [[1., 2.], [3., 4.], [5., 6.], [7., 8.], [9., 10.]]
+
+        Distribute over 2 partitions
+        >>> rdd = sc.parallelize(mylist, 2)
+
+        Compute the centroid for each partition
+        >>> cf = CollapseFunctions()
+        >>> data = rdd.mapPartitions(
+        ...     lambda partition: cf.mean(partition)).collect()
+        >>> print(data)
+        [(array([ 2.,  3.]), 2), (array([ 7.,  8.]), 3)]
+
+        If there are empty partitions, it returns None for the empty ones.
+        >>> rdd = sc.parallelize(mylist, 6)
+        >>> cf = CollapseFunctions()
+        >>> data = rdd.mapPartitions(
+        ...     lambda partition: cf.mean(partition)).collect()
+        >>> centroids = [c[0] for c in data]
+        >>> print(centroids) # doctest: +NORMALIZE_WHITESPACE
+        [None, array([ 1.,  2.]), array([ 3.,  4.]), array([ 5.,  6.]),
+        array([ 7.,  8.]), array([  9.,  10.])]
+
+        """
+        import numpy as np
+
+        # Loop over elements of the partition
+        xyz = [item for item in partition]
+        size = len(xyz)
+
+        # Compute the centroid only if the partition is not empty
+        if size > 0:
+            mean = np.mean(xyz, axis=0)
+        else:
+            mean = None
+
+        yield (mean, size)
+
+    def kmeans(self, partition: Iterator, k: int=1) -> (list, int):
+        """Performs k-means on a the elements of the partition.
+        The case k=1 corresponds to the function `mean` above.
+
+        Parameters
+        ----------
+        partition : Iterator
+            Iterator over the elements of the Spark partition.
+        k : int, optional
+            The number of centroids to generate. Default is 1 (mean).
+
+        Returns
+        -------
+        (list, int)
+            The list of centroids, and the total number of points in the
+            partition. If the partition is empty, return ([None], 0).
+
+        Examples
+        -------
+        List of coordinates (can be 2D, 3D, ..., nD)
+        >>> mylist = [
+        ...     [1., 2., 4.], [3., 4., 1.], [5., 6., 5.],
+        ...     [9., 10., 7.], [1., 2., 7.], [3., 4., 6.],
+        ...     [5., 6., 9.], [7., 8., 6.], [9., 10., 10.]]
+
+        Distribute over 2 partitions
+        >>> rdd = sc.parallelize(mylist, 2)
+
+        Compute the centroid for each partition
+        >>> cf = CollapseFunctions()
+        >>> data = rdd.mapPartitions(
+        ...     lambda partition: cf.kmeans(partition, 1)).collect()
+        >>> print(data) # doctest: +NORMALIZE_WHITESPACE
+        [(array([[ 4.5 ,  5.5 ,  4.25]]), 4), (array([[ 5. ,  6. ,  7.6]]), 5)]
+
+        If there are empty partitions, it returns None for the empty ones.
+        >>> rdd = sc.parallelize(mylist, 10)
+        >>> cf = CollapseFunctions()
+        >>> data = rdd.mapPartitions(
+        ...     lambda partition: cf.kmeans(partition, 1)).collect()
+        >>> centroids = [c[0] for c in data]
+        >>> print(centroids) # doctest: +NORMALIZE_WHITESPACE
+        [[None], array([[ 1.,  2.,  4.]]), array([[ 3.,  4.,  1.]]),
+        array([[ 5.,  6.,  5.]]), array([[  9.,  10.,   7.]]),
+        array([[ 1.,  2.,  7.]]), array([[ 3.,  4.,  6.]]),
+        array([[ 5.,  6.,  9.]]), array([[ 7.,  8.,  6.]]),
+        array([[  9.,  10.,  10.]])]
+
+        """
+        from scipy.cluster.vq import kmeans
+
+        # Loop over elements of the partition
+        xyz = [item for item in partition]
+        size = len(xyz)
+
+        if len(xyz) > k - 1:
+            centers, distortion = kmeans(xyz, k)
+        else:
+            centers = [None]
+
+        yield (centers, size)
+
+
+def collapse_rdd_data(
+        rdd: RDD, collapse_function: Callable[[Iterator, Any], tuple],
+        *args: Any):
+    """Apply a collapse function to reduce the size of the data
+    set. The function is applied for each partition (mapPartitions).
+
+    Parameters
+    ----------
+    rdd : RDD[list[float]]
+        RDD of list of float. Each list is the coordinate of a point (x, y, z).
+    collapse_function : function
+        collapse function to reduce the size of the data set. See
+        `CollapseFunctions` for more information.
+    args: Any
+        Any arguments that have to be passed to `collapse_function`.
+        Must be comma-separated.
+
+    Returns
+    -------
+    RDD
+        RDD whose elements are the result of the collapse function for
+        each partition.
+
+    Examples
+    -------
+    List of coordinates (can be 2D, 3D, ..., nD)
+    >>> mylist = [
+    ...     [1., 2., 4.], [3., 4., 1.], [5., 6., 5.],
+    ...     [9., 10., 7.], [1., 2., 7.], [3., 4., 6.],
+    ...     [5., 6., 9.], [7., 8., 6.], [9., 10., 10.]]
+
+    Distribute over 2 partitions
+    >>> rdd = sc.parallelize(mylist, 2)
+
+    Compute the centroid for each partition
+    >>> cf = CollapseFunctions()
+    >>> data = collapse_rdd_data(rdd, cf.kmeans, 1).collect()
+    >>> print(data) # doctest: +NORMALIZE_WHITESPACE
+    [(array([[ 4.5 ,  5.5 ,  4.25]]), 4), (array([[ 5. ,  6. ,  7.6]]), 5)]
+
+    """
+    return rdd.mapPartitions(
+        lambda partition: collapse_function(partition, *args))
+
+def scatter3d_mpl(x, y, z, radius=None):
+    """3D scatter plot from matplotlib
+
+    Parameters
+    ----------
+    partitioned_rdd : RDD
+        RDD[T] where T can be Point3D, ShellEnvelope, BoxEnvelope.
+
+    Examples
+    -------
+    Examples should be written in doctest format, and
+    should illustrate how to use the function/class.
+    >>>
+
+    """
+    import pylab as pl
+    from mpl_toolkits.mplot3d import Axes3D
+
+    fig = pl.figure()
+    ax = Axes3D(fig)
+
+    # Size of the centroids
+    if radius is None:
+        rad = 10.
+    else:
+        assert len(radius) == len(x), "Wrong size!"
+        rad = radius
+
+    ax.scatter(x, y, z, s=rad)
+    pl.show()
+
+
+if __name__ == "__main__":
+    """
+    Run the doctest using
+
+    python visualisation.py
+
+    If the tests are OK, the script should exit gracefuly, otherwise the
+    failure(s) will be printed out.
+    """
+    import sys
+    import doctest
+    import numpy as np
+
+    from pyspark import SparkContext
+    from pyspark3d import pyspark3d_conf
+    from pyspark3d import load_user_conf
+
+    # Activate the SparkContext for the test suite
+    dic = load_user_conf()
+    conf = pyspark3d_conf("local", "test", dic)
+    sc = SparkContext.getOrCreate(conf=conf)
+
+    # Numpy introduced non-backward compatible change from v1.14.
+    if np.__version__ >= "1.14.0":
+        np.set_printoptions(legacy="1.13")
+
+    # Run the test suite
+    failure_count, test_count = doctest.testmod()
+    sys.exit(failure_count)


### PR DESCRIPTION
This PR introduces tools to quickly visually inspect RDD. 

When speaking of visualisation in Apache Spark, obviously the main problem is the data set size, which makes the visualisation challenging. 

There are several tools in the market to deal with very large data sets, but most of them are not open source, or read their data only from files on disk, or are too complex to make anything simple in 2 sec (as you would like to have when prototyping). If you know one great that I could have missed, let me know!

I really wanted a simple tool to make live RDD visualisation (which translates basically to _"hey, how look like the data in this RDD?"_, no matter the size of it).

In order to leverage this, we introduce _collapse functions_. Collapse functions are functions acting on the data set to make a representation of it. They are applied at the level of each partition, to reduce the size of the data set while keeping desired features. Obviously, that means the data in your RDD have some kind of ordered, for the procedure to be meaningful (in other words, the RDD has been repartitioned in some way).

Let's take a concrete example. I have a several million 3D points RDD from a FITS file:
```python
from pyspark3d.spatial3DRDD import Point3DRDD

p3d = Point3DRDD(spark, fn, "x,y,z", False, "fits", {"hdu": hdu})
```
The data is a priori randomly distributed (spatially), so I need to re-partition it:

```python
from pyspark3d.converters import toCoordRDD

# Perform the re-partitioning, and convert to Python RDD
crdd = toCoordRDD(p3d, gridtype, npart).cache()
```

Note that the re-partitioning is done in Scala under the hood, but we transfer a PythonRDD at the end whose elements are the coordinates of the 3D points (and drop all the other metadata).
Let's now reduce the size of the data set by collapsing each partition into its centroid:

```python
from pyspark3d.visualisation import CollapseFunctions
from pyspark3d.visualisation import collapse_rdd_data

# Collapse the data using a simple mean of each partition (centroid)
cf = CollapseFunctions()
data = collapse_rdd_data(crdd, cf.mean).collect()
```
And finally here is what I get!

![test_collapse_function_mean](https://user-images.githubusercontent.com/20426972/45534182-a1db2200-b7fa-11e8-9db9-80c73cd84b00.png)


