### PR TITLE
Several updates to the Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,101 +1,71 @@
-dist: trusty
-
-language: java
-
-jdk: oraclejdk8
+language: scala
 
 sudo: required
 
-services:
-  - docker
+dist: trusty
 
 cache:
   directories:
-  - $HOME/.ivy2/
-  - $HOME/.sbt/launchers/
-  - $HOME/.cache/spark-versions/
-  - $HOME/.sbt/boot/scala-2.10.6/
-  - $HOME/.sbt/boot/scala-2.11.8/
+    - $HOME/.ivy2
+    - $HOME/spark
+    - $HOME/.cache/pip
+    - $HOME/.pip-cache
+    - $HOME/.sbt/launchers
 
-env:
-  matrix:
-    - SCALA_BINARY_VERSION=2.11.8 SPARK_VERSION=2.3.0 SPARK_BUILD="spark-2.3.0-bin-hadoop2.7"
-        SPARK_BUILD_URL="https://dist.apache.org/repos/dist/release/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz"
-        PYTHON_VERSION=3.6.4
+jdk:
+  - oraclejdk8
+
+scala:
+   - 2.11.8
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - axel
 
 before_install:
-  # Link to python 2 or 3
-  - if [[ "$PYTHON_VERSION" == 2.* ]]; then
-        export CONDA_URL="repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh"
-        export PYSPARK_PYTHON=python2;
-      else
-        export CONDA_URL="repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh";
-        export PYSPARK_PYTHON=python3;
-      fi
-  # Run the base image (Ubuntu 16.04) and set the env
-  - docker run -e "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"
-               -e SPARK_VERSION
-               -e SPARK_BUILD
-               -e SCALA_BINARY_VERSION
-               -e PYTHON_VERSION
-               -e PYSPARK_PYTHON
-               -e CONDA_URL
-               -d --name ubuntu-test -v $HOME ubuntu:16.04 tail -f /dev/null
-  # Copy our file to the image
-  - docker cp `pwd` ubuntu-test:$HOME/
-  # Copy the cache to speed-up later call
-  - docker cp $HOME/.cache ubuntu-test:$HOME/
-  # For debug - show the process
-  - docker ps
+  - export PATH=$HOME/.local/bin:$PATH
+  - pip install --user codecov coverage
 
-# See this page: http://conda.pydata.org/docs/travis.html
 install:
-  # install needed ubuntu packages
-  - docker exec -t ubuntu-test bash -c "apt-get update && apt-get upgrade -y"
-  - docker exec -t ubuntu-test bash -c "apt-get install -y curl bzip2 openjdk-8-jdk"
+  # Download spark 2.3.1
+  - "[ -f spark ] || mkdir spark && cd spark && axel http://www-us.apache.org/dist/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && cd .."
+  - tar -xf ./spark/spark-2.3.1-bin-hadoop2.7.tgz
+  - export SPARK_HOME=`pwd`/spark-2.3.1-bin-hadoop2.7
+  - echo "spark.yarn.jars=$SPARK_HOME/jars/*.jar" > $SPARK_HOME/conf/spark-defaults.conf
 
-  # download and set up miniconda
-  - docker exec -t ubuntu-test bash -c "
-      curl https://$CONDA_URL >> $HOME/miniconda.sh;
-      bash $HOME/miniconda.sh -b -p $HOME/miniconda;
-      bash $HOME/miniconda.sh -b -p $HOME/miniconda;
-      $HOME/miniconda/bin/conda config --set always_yes yes --set changeps1 no;
-      $HOME/miniconda/bin/conda update -q conda;
-      $HOME/miniconda/bin/conda info -a;
-      $HOME/miniconda/bin/conda create -q -n test-environment python=$PYTHON_VERSION"
+  # Install Python deps.
+  # The conda installation steps here are based on http://conda.pydata.org/docs/travis.html
+  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # In case you need to debug any issues with conda
+  - conda info -a
+  # Install deps -- TODO: use the requirements.txt file.
+  - deps='pip coverage py4j numpy scipy'
 
-  # Install SBT (long - need to speed-up this!)
-  - docker exec -t ubuntu-test bash -c "apt-get install apt-transport-https"
-  - docker exec -t ubuntu-test bash -c "
-      echo 'deb https://dl.bintray.com/sbt/debian /' | tee -a /etc/apt/sources.list.d/sbt.list;
-      apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823;
-      apt-get update -y;
-      apt-get install sbt -y"
-
-  # Activate conda environment and install required packages
-  - docker exec -t ubuntu-test bash -c "
-      source $HOME/miniconda/bin/activate test-environment;
-      python --version;
-      pip --version;
-      pip install --user -r $HOME/spark3D/requirements.txt;"
+  # Test with python 3.6
+  - conda create -p $HOME/py --yes $deps "python=3.6"
+  - export PATH=$HOME/py/bin:$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH
+  - export PYTHONPATH="$SPARK_HOME/python:$PYTHONPATH"
+  - pip install --upgrade codecov
 
 script:
-  # Run the scala unit tests first and send coverage data
-  # This step is currently the longer as one needs to initialise SBT
-  # and download millions of packages...
-  - ci_env=`bash <(curl -s https://codecov.io/env)`
-  - docker exec $ci_env -t ubuntu-test bash -c "
-      source $HOME/miniconda/bin/activate test-environment;
-      cd $HOME/spark3D;
-      ./test_scala.sh $SCALA_BINARY_VERSION;
-      bash <(curl -s https://codecov.io/bash) -cF scala"
+  # TODO: replace this with pip install once the setup.py is done.
+  - export S3DHOME="/home/travis/build/astrolabsoftware/spark3D"
+  - export PYTHONPATH="$S3DHOME:$S3DHOME/pyspark3d:$PYTHONPATH"
+  # Test with Scala 2.11
+  - export SCALA_BINARY_VERSION="2.11.8"
 
-  # Run the python unit tests (which includes building the
-  # assembly JAR) and send coverage data.
-  - docker exec $ci_env -t ubuntu-test bash -c "
-      source $HOME/miniconda/bin/activate test-environment;
-      cd $HOME/spark3D;
-      export PATH=/root/.local/bin:$PATH;
-      export PYTHONPATH=$HOME/spark3D:$PYTHONPATH;
-      ./test_python.sh $SCALA_BINARY_VERSION;
-      bash <(curl -s https://codecov.io/bash) -cF python"
+  # Scala tests
+  - ./test_scala.sh $SCALA_BINARY_VERSION
+  - bash <(curl -s https://codecov.io/bash) -cF scala
+
+  # Python tests
+  - ./test_python.sh $SCALA_BINARY_VERSION
+  - bash <(curl -s https://codecov.io/bash) -cF python

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.14
 coverage>=4.2
 pyspark
 coveralls
+scipy


### PR DESCRIPTION
This PR fixes several points:
- Failing python tests seen in e.g. [here](https://travis-ci.org/astrolabsoftware/spark3D/builds/428553283) are fixed (could not fix the nasty `java.io.IOException: Cannot run program "/opt/pyenv/shims/python3": error=2, No such file or directory` error in travis+docker env...)
- Travis build now fails if python tests fail.

Moreover cache is used for SBT, so the test suite is twice faster.