### PR TITLE
Deploy pyspark3d with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,32 @@
 - [07/2018] **New location**: spark3D is an official project of [AstroLab Software](https://astrolabsoftware.github.io/)!
 - [07/2018] **Release**: version 0.1.3, 0.1.4, 0.1.5
 - [08/2018] **Release**: version 0.2.0, 0.2.1 (pyspark3d)
+- [09/2018] **Release**: version 0.2.2 (pip installation)
 
 <p align="center"><img width="500" src="https://github.com/astrolabsoftware/spark3D/raw/master/pic/spark3d_lib_0.2.1.png"/>
 </p>
 
 ## Installation and tutorials
+
+### Scala
+
+You can link spark3D to your project (either spark-shell or spark-submit) by specifying the coordinates:
+
+```
+spark-submit --packages "com.github.astrolabsoftware:spark3d_2.11:0.2.1"
+```
+
+### Python
+
+Just run
+
+```bash
+pip install pyspark3d
+```
+
+Note that we release the assembly JAR with it.
+
+### More information
 
 See our amazing [website](https://astrolabsoftware.github.io/spark3D/)!
 

--- a/docs/01_installation.md
+++ b/docs/01_installation.md
@@ -105,22 +105,39 @@ objects in the Java Virtual Machine, and then Python programs running in a Pytho
 pyspark3d is tested on Python 3.5 and later.
 **Note: pyspark3d will not run for python 3.4 and earlier (incl. 2.X).** The reason is
 that we make use of [type hints](https://www.python.org/dev/peps/pep-0484/):
+
 ```
 PEP 484, the typing module, a new standard for type annotations.
 ```
 
 In addition, pyspark3d requires:
 
-- `pyspark` (python)
-- `spark-fits` (scala)
+- `pyspark`
+- `numpy`
+- `scipy`
 
 You can find all python dependencies in the `requirements.txt` file at the root of the project.
+It needs also `coverage` and `coveralls` if you want to run the test suite.
+
+Note that `pyspark3d` depends on [spark-fits](https://github.com/astrolabsoftware/spark-fits),
+but this dependency is included in the assembly JARS (see below).
 
 ## Including spark3D in your project
 
 In case you are completely lost, have a look at the `.travis.yml` file at the
 root of the project. It will give you a hint on how to install the project
 on ubuntu 16.04.
+
+### Using pip
+
+Just run
+
+```bash
+pip install pyspark3d
+```
+
+Note that we release the assembly JAR with it.
+
 
 ### Manual
 
@@ -135,31 +152,8 @@ toto:~$ cd /path/to/spark3D
 toto:~$ sbt ++${SCALA_VERSION} assembly
 ```
 
-Edit the `pyspark3d_conf.py` with the newly created JAR:
-
-```python
-# in pyspark3d_conf.py
-
-...
-
-# spark3D version
-version = __version__
-
-# Scala version used to compile spark3D
-scala_version = __scala_version__
-
-...
-
-# External JARS to be added to both driver and executors
-# Should contain the FAT JAR of spark3D.
-extra_jars = [
-    os.path.join(
-        path_to_conf, "../target/scala-{}/spark3D-assembly-{}.jar".format(
-            scala_version, version))
-]
-```
-
-Make sure spark3D is also in your PYTHONPATH:
+Edit the `pyspark3d_conf.py` with the newly created JAR, and
+make sure spark3D is also in your PYTHONPATH:
 
 ```bash
 # in ~/.bash_profile for example
@@ -167,10 +161,6 @@ Make sure spark3D is also in your PYTHONPATH:
 export PYTHONPATH=/path/to/spark3D:$PYTHONPATH
 ...
 ```
-
-### Using pip
-
-To come.
 
 ## Running the test suite
 

--- a/pyspark3d/__init__.py
+++ b/pyspark3d/__init__.py
@@ -17,11 +17,11 @@ from pyspark.sql import SparkSession
 
 from typing import Any, List, Dict
 
-from pyspark3d_conf import extra_jars
-from pyspark3d_conf import extra_packages
-from pyspark3d_conf import log_level
+from pyspark3d.pyspark3d_conf import extra_jars
+from pyspark3d.pyspark3d_conf import extra_packages
+from pyspark3d.pyspark3d_conf import log_level
 
-from version import __version__
+from pyspark3d.version import __version__
 
 ROOT_JVM = "_gateway.jvm"
 

--- a/pyspark3d/pyspark3d_conf.py
+++ b/pyspark3d/pyspark3d_conf.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 from pathlib import Path
-from version import __version__, __scala_version__
+from pyspark3d.version import __version__, __scala_version__
 
 # For local tests
 path_to_conf = Path().cwd().as_uri()
@@ -32,10 +32,10 @@ log_level = "WARN"
 
 # External JARS to be added to both driver and executors
 # Should contain the FAT JAR of spark3D.
+where_is_my_jar = os.path.abspath(os.path.dirname(__file__))
 extra_jars = [
     os.path.join(
-        path_to_conf, "../target/scala-{}/spark3D-assembly-{}.jar".format(
-            scala_version, version))
+        where_is_my_jar, "spark3D-assembly-{}.jar".format(version))
 ]
 
 # External packages specified using their Maven coordinates

--- a/pyspark3d/pyspark3d_conf.py
+++ b/pyspark3d/pyspark3d_conf.py
@@ -32,11 +32,26 @@ log_level = "WARN"
 
 # External JARS to be added to both driver and executors
 # Should contain the FAT JAR of spark3D.
-where_is_my_jar = os.path.abspath(os.path.dirname(__file__))
-extra_jars = [
-    os.path.join(
-        where_is_my_jar, "spark3D-assembly-{}.jar".format(version))
-]
+here = os.path.abspath(os.path.dirname(__file__))
+
+# If the package has been installed with pip, the JAR
+# is released with the py files
+from_pip = os.path.join(here, "spark3D-assembly-{}.jar".format(version))
+
+# If the package is built from sources, then the JAR
+# is in the spark3D target/scala-{version} folder.
+from_source = os.path.join(
+    here, "../target/scala-{}/spark3D-assembly-{}.jar".format(
+        scala_version, version))
+
+if os.path.isfile(from_pip):
+    extra_jar = from_pip
+elif os.path.isfile(from_source):
+    extra_jar = from_source
+else:
+    extra_jar = ""
+
+extra_jars = [extra_jar]
 
 # External packages specified using their Maven coordinates
 extra_packages = [

--- a/pyspark3d/spatial3DRDD.py
+++ b/pyspark3d/spatial3DRDD.py
@@ -16,7 +16,7 @@ from pyspark.sql import SparkSession
 from py4j.java_gateway import JavaObject
 
 from pyspark3d import load_from_jvm
-from pyspark3d_conf import path_to_conf
+from pyspark3d.pyspark3d_conf import path_to_conf
 
 import os
 from typing import Dict

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+## TODO before bumping version:
+##  - run sbt clean
+##  - update build.sbt
+##  - update website (01_installation.md, picture of the package, _pages/home.md, )
+##  - update README.md
+##  - update pyspark3d/version.py
+##  - update the CHANGELOG.md
+##  - update the runners
+##  - update the notebook, examples
+## THEN:
+
+## GitHub
+git tag <name>
+git push origin --tags
+
+## Maven - Scala 2.11
+sbt ++2.11.8 publishSigned
+sbt ++2.11.8 sonatypeRelease
+
+## pypi
+python setup.py sdist bdist_wheel
+twine upload dist/*
+
+## Note: to be automated! And clean the repo after this.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy>=1.14
 coverage>=4.2
-pyspark
 coveralls
 scipy

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ from distutils.command.clean import clean
 from distutils.command.sdist import sdist
 from distutils.spawn import find_executable
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 requirements = ["numpy>=1.14", "pyspark", "scipy"]
 setup_requirements = ["wheel"]
 test_requirements = ["coverage>=4.2", "coveralls"]
@@ -99,7 +102,8 @@ setup(
     name='pyspark3d',
     version=VERSION,
     description="Spark extension for processing large-scale 3D data sets",
-    long_description="",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author="AstroLab Software",
     author_email='peloton@lal.in2p3.fr',
     url='https://github.com/astrolabsoftware/spark3d',
@@ -120,16 +124,6 @@ setup(
         'clean': jar_clean,
         'sdist': my_sdist,
     },
-    # package_data={
-    #     '.': [
-    #         'build.sbt',
-    #         'LICENCE',
-    #         'project',
-    #         'src',
-    #         ASSEMBLY_JAR
-    #     ]
-    # },
-    # package_data={'target/scala-2.11': ['{}'.format(ASSEMBLY_JAR_S)]},
     include_package_data=True,
     setup_requires=setup_requirements
 )


### PR DESCRIPTION
`pip install pyspark3d`

Still to be understood:
- We release the assembly JAR with the package. I couldn't find how to load it within a pyspark shell session if it has not been added using `--jars ...`.