### PR TITLE
Clarify the use of get_spark_session and load_user_conf (for tests only!)

### DIFF
--- a/docs/03_partitioning_python.md
+++ b/docs/03_partitioning_python.md
@@ -25,12 +25,14 @@ There are currently 2 partitioning implemented in the library:
 In the following example, we load `Point3D` data, and we re-partition it with the onion partitioning
 
 ```python
-from pyspark3d import load_user_conf, get_spark_session
+# Launch this example: spark-submit --master ... --packages spark3D_id
+from pyspark.sql import SparkSession
 from pyspark3d.spatial3DRDD import Point3DRDD
 
-# Load user config and the Spark session
-dic = load_user_conf()
-spark = get_spark_session(dicconf=dic)
+# Initialise Spark Session
+spark = SparkSession.builder\
+    .appName("collapse")\
+    .getOrCreate()
 
 # Load the data
 fn = "src/test/resources/astro_obs.fits"
@@ -54,12 +56,14 @@ Color code indicates the partitions (all objects with the same color belong to t
 In the following example, we load `ShellEnvelope` data (spheres), and we re-partition it with the octree partitioning
 
 ```python
-from pyspark3d import load_user_conf, get_spark_session
+# Launch this example: spark-submit --master ... --packages spark3D_id
+from pyspark.sql import SparkSession
 from pyspark3d.spatial3DRDD import SphereRDD
 
-# Load user config and the Spark session
-dic = load_user_conf()
-spark = get_spark_session(dicconf=dic)
+# Initialise Spark Session
+spark = SparkSession.builder\
+    .appName("collapse")\
+    .getOrCreate()
 
 # Load the data
 fn = "src/test/resources/cartesian_spheres.fits"

--- a/docs/04_query_python.md
+++ b/docs/04_query_python.md
@@ -14,16 +14,16 @@ The spark3D library contains a number of methods and tools to manipulate 3D RDD.
 A Envelope query takes as input a `RDD[Shape3D]` and an envelope, and returns all objects in the RDD intersecting the envelope (contained in and crossing the envelope):
 
 ```python
-from pyspark3d import get_spark_session
-from pyspark3d import load_user_conf
-
+# Launch this example: spark-submit --master ... --packages spark3D_id
+from pyspark.sql import SparkSession
 from pyspark3d.geometryObjects import ShellEnvelope
 from pyspark3d.spatial3DRDD import SphereRDD
 from pyspark3d.spatialOperator import windowQuery
 
-# Load the user configuration, and initialise the spark session.
-dic = load_user_conf()
-spark = get_spark_session(dicconf=dic)
+# Initialise Spark Session
+spark = SparkSession.builder\
+    .appName("collapse")\
+    .getOrCreate()
 
 # Load the data
 fn = "src/test/resources/cartesian_spheres.fits"
@@ -46,14 +46,14 @@ Note that the input objects and the envelope can be anything among the `Shape3D`
 A cross-match takes as input two data sets, and return objects matching based on the center distance, or pixel index of objects. Note that performing a cross-match between a data set of N elements and another of M elements is a priori a NxM operation - so it can be very costly! Let's load two `Point3D` data sets:
 
 ```python
-from pyspark3d import get_spark_session
-from pyspark3d import load_user_conf
-
+# Launch this example: spark-submit --master ... --packages spark3D_id
+from pyspark.sql import SparkSession
 from pyspark3d.spatial3DRDD import Point3DRDD
 
-# Load the user configuration, and initialise the spark session.
-dic = load_user_conf()
-spark = get_spark_session(dicconf=dic)
+# Initialise Spark Session
+spark = SparkSession.builder\
+    .appName("collapse")\
+    .getOrCreate()
 
 # Load the raw data (spherical coordinates)
 fn = "src/test/resources/astro_obs_{}_light.fits"
@@ -147,16 +147,16 @@ Note that `queryObject` and elements of `rdd` must have the same type
 (either both Point3D, or both ShellEnvelope, or both BoxEnvelope).
 
 ```python
-from pyspark3d import get_spark_session
-from pyspark3d import load_user_conf
-
+# Launch this example: spark-submit --master ... --packages spark3D_id
+from pyspark.sql import SparkSession
 from pyspark3d.geometryObjects import Point3D
 from pyspark3d.spatial3DRDD import Point3DRDD
 from pyspark3d.spatialOperator import KNN
 
-# Load the user configuration, and initialise the spark session.
-dic = load_user_conf()
-spark = get_spark_session(dicconf=dic)
+# Initialise Spark Session
+spark = SparkSession.builder\
+    .appName("collapse")\
+    .getOrCreate()
 
 # Load the data (spherical coordinates)
 fn = "src/test/resources/astro_obs.fits"
@@ -213,16 +213,16 @@ among Shape3D (Point3D or ShellEnvelope or BoxEnvelope) (unlike KNN above).
 Note 2: KNNEfficient only works on repartitioned RDD (python version).
 
 ```python
-from pyspark3d import get_spark_session
-from pyspark3d import load_user_conf
-
+# Launch this example: spark-submit --master ... --packages spark3D_id
+from pyspark.sql import SparkSession
 from pyspark3d.geometryObjects import Point3D
 from pyspark3d.spatial3DRDD import Point3DRDD
 from pyspark3d.spatialOperator import KNN
 
-# Load the user configuration, and initialise the spark session.
-dic = load_user_conf()
-spark = get_spark_session(dicconf=dic)
+# Initialise Spark Session
+spark = SparkSession.builder\
+    .appName("collapse")\
+    .getOrCreate()
 
 # Load the data (spherical coordinates)
 fn = "src/test/resources/astro_obs.fits"

--- a/docs/about.md
+++ b/docs/about.md
@@ -38,8 +38,9 @@ Several goals have to be undertaken in this project:
   + indexing mechanisms
   + ways to define a metric (ie. distance between objects)
   + selection capability of objects or objects within a region
+  + ways to visualise 3D data
 - work with as many input file format as possible (CSV, ROOT, FITS, HDF5 and so on)
-- Expose several API: Scala and Python at least!
+- expose several API: Scala and Python at least!
 - package the developments into an open-source library.
 
 ## Current structure

--- a/examples/python/collapse_functions.py
+++ b/examples/python/collapse_functions.py
@@ -17,8 +17,6 @@ import numpy as np
 import pylab as pl
 
 from pyspark3d import set_spark_log_level
-from pyspark3d import load_user_conf
-from pyspark3d import get_spark_session
 from pyspark3d.spatial3DRDD import Point3DRDD
 from pyspark3d.visualisation import scatter3d_mpl
 from pyspark3d.visualisation import CollapseFunctions
@@ -73,9 +71,10 @@ if __name__ == "__main__":
     addargs(parser)
     args = parser.parse_args(None)
 
-    # Load user conf and Spark session
-    dic = load_user_conf()
-    spark = get_spark_session(dicconf=dic)
+    # Initialise Spark Session
+    spark = SparkSession.builder\
+        .appName("collapse")\
+        .getOrCreate()
 
     # Set logs to be quiet
     set_spark_log_level()

--- a/examples/python/pyspark3d_octree_part.py
+++ b/examples/python/pyspark3d_octree_part.py
@@ -16,8 +16,6 @@ from pyspark.sql import SparkSession
 import numpy as np
 
 from pyspark3d import set_spark_log_level
-from pyspark3d import load_user_conf
-from pyspark3d import get_spark_session
 from pyspark3d.spatial3DRDD import SphereRDD
 
 import argparse
@@ -68,9 +66,10 @@ if __name__ == "__main__":
     addargs(parser)
     args = parser.parse_args(None)
 
-    # Load user conf and Spark session
-    dic = load_user_conf()
-    spark = get_spark_session(dicconf=dic)
+    # Initialise Spark Session
+    spark = SparkSession.builder\
+        .appName("collapse")\
+        .getOrCreate()
 
     # Set logs to be quiet
     set_spark_log_level()
@@ -102,7 +101,7 @@ if __name__ == "__main__":
         fig = pl.figure()
         ax = Axes3D(fig)
 
-        # Convert data for plot
+        # Convert data for plot -- Maybe use toCoordRDD instead...
         # List[all partitions] of List[all Point3D per partition]
         data_glom = rdd_part.glom().collect()
 

--- a/examples/python/pyspark3d_onion_part.py
+++ b/examples/python/pyspark3d_onion_part.py
@@ -16,8 +16,6 @@ from pyspark.sql import SparkSession
 import numpy as np
 
 from pyspark3d import set_spark_log_level
-from pyspark3d import load_user_conf
-from pyspark3d import get_spark_session
 from pyspark3d import load_from_jvm
 from pyspark3d.spatial3DRDD import Point3DRDD
 
@@ -69,9 +67,10 @@ if __name__ == "__main__":
     addargs(parser)
     args = parser.parse_args(None)
 
-    # Load user conf and Spark session
-    dic = load_user_conf()
-    spark = get_spark_session(dicconf=dic)
+    # Initialise Spark Session
+    spark = SparkSession.builder\
+        .appName("collapse")\
+        .getOrCreate()
 
     # Set logs to be quiet
     set_spark_log_level()
@@ -109,6 +108,7 @@ if __name__ == "__main__":
         converter = load_from_jvm(mod)
 
         # Convert data for plot -- List of List of Point3D
+        # Maybe use toCoordRDD instead...
         data_glom = rdd_part.glom().collect()
 
         # Take only a few points (400 per partition) to speed-up

--- a/pyspark3d/converters.py
+++ b/pyspark3d/converters.py
@@ -179,14 +179,8 @@ def toCoordRDD(
 
     Examples
     -------
-    >>> from pyspark3d import get_spark_session
-    >>> from pyspark3d import load_user_conf
     >>> from pyspark3d_conf import path_to_conf
     >>> from pyspark3d.spatial3DRDD import Point3DRDD
-
-    Load the user configuration, and initialise the spark session.
-    >>> dic = load_user_conf()
-    >>> spark = get_spark_session(dicconf=dic)
 
     Load data
     >>> fn = os.path.join(path_to_conf, "../src/test/resources/astro_obs.fits")
@@ -254,16 +248,21 @@ if __name__ == "__main__":
     from pyspark import SparkContext
     from pyspark3d import pyspark3d_conf
     from pyspark3d import load_user_conf
+    from pyspark3d import get_spark_session
 
     # Activate the SparkContext for the test suite
     dic = load_user_conf()
     conf = pyspark3d_conf("local[*]", "test", dic)
     sc = SparkContext.getOrCreate(conf=conf)
 
+    # Load the spark3D JAR+deps, and initialise the spark session.
+    # In a pyspark shell, you do not need this.
+    spark = get_spark_session(dicconf=dic)
+
     # Numpy introduced non-backward compatible change from v1.14.
     if np.__version__ >= "1.14.0":
         np.set_printoptions(legacy="1.13")
 
     # Run the test suite
-    failure_count, test_count = doctest.testmod()
+    failure_count, test_count = doctest.testmod(extraglobs={"spark": spark})
     sys.exit(failure_count)

--- a/pyspark3d/pyspark3d_conf.py
+++ b/pyspark3d/pyspark3d_conf.py
@@ -15,6 +15,12 @@ import os
 from pathlib import Path
 from pyspark3d.version import __version__, __scala_version__
 
+# In principle, users do not need to load all this stuff below.
+# It is mainly used in 2 contexts:
+#   - Running the test suite
+#   - Using spark3D within a standard ipython or notebook session
+# In those two cases, you need to load the JAR+deps within the session.
+
 # For local tests
 path_to_conf = Path().cwd().as_uri()
 

--- a/pyspark3d/spatial3DRDD.py
+++ b/pyspark3d/spatial3DRDD.py
@@ -82,13 +82,6 @@ def Point3DRDD(
 
     Examples
     ----------
-    >>> from pyspark3d import get_spark_session
-    >>> from pyspark3d import load_user_conf
-
-    Load the user configuration, and initialise the spark session.
-    >>> dic = load_user_conf()
-    >>> spark = get_spark_session(dicconf=dic)
-
     Load data
     >>> fn = os.path.join(path_to_conf, "../src/test/resources/astro_obs.fits")
     >>> rdd = Point3DRDD(spark, fn, "Z_COSMO,RA,DEC",
@@ -200,13 +193,6 @@ def SphereRDD(
 
     Examples
     ----------
-    >>> from pyspark3d import get_spark_session
-    >>> from pyspark3d import load_user_conf
-
-    Load the user configuration, and initialise the spark session.
-    >>> dic = load_user_conf()
-    >>> spark = get_spark_session(dicconf=dic)
-
     Load the data
     >>> fn = os.path.join(path_to_conf,
     ...     "../src/test/resources/cartesian_spheres.fits")
@@ -275,6 +261,14 @@ if __name__ == "__main__":
     if np.__version__ >= "1.14.0":
         np.set_printoptions(legacy="1.13")
 
+    from pyspark3d import get_spark_session
+    from pyspark3d import load_user_conf
+
+    # Load the spark3D JAR+deps, and initialise the spark session.
+    # In a pyspark shell, you do not need this.
+    dic = load_user_conf()
+    spark = get_spark_session(dicconf=dic)
+
     # Run the test suite
-    failure_count, test_count = doctest.testmod()
+    failure_count, test_count = doctest.testmod(extraglobs={"spark": spark})
     sys.exit(failure_count)

--- a/pyspark3d/spatialOperator.py
+++ b/pyspark3d/spatialOperator.py
@@ -43,15 +43,9 @@ def windowQuery(rdd: JavaObject, envelope: JavaObject) -> JavaObject:
 
     Examples
     ----------
-    >>> from pyspark3d import get_spark_session
-    >>> from pyspark3d import load_user_conf
     >>> from pyspark3d.geometryObjects import ShellEnvelope
     >>> from pyspark3d_conf import path_to_conf
     >>> from pyspark3d.spatial3DRDD import SphereRDD
-
-    Load the user configuration, and initialise the spark session.
-    >>> dic = load_user_conf()
-    >>> spark = get_spark_session(dicconf=dic)
 
     Load the data
     >>> fn = os.path.join(path_to_conf,
@@ -119,15 +113,9 @@ def KNN(
 
     Examples
     ----------
-    >>> from pyspark3d import get_spark_session
-    >>> from pyspark3d import load_user_conf
     >>> from pyspark3d.geometryObjects import Point3D
     >>> from pyspark3d_conf import path_to_conf
     >>> from pyspark3d.spatial3DRDD import Point3DRDD
-
-    Load the user configuration, and initialise the spark session.
-    >>> dic = load_user_conf()
-    >>> spark = get_spark_session(dicconf=dic)
 
     Load the data (spherical coordinates)
     >>> fn = os.path.join(path_to_conf, "../src/test/resources/astro_obs.fits")
@@ -198,15 +186,9 @@ def KNNEfficient(rdd: JavaObject, queryObject: JavaObject, k: int) -> list:
 
     Examples
     ----------
-    >>> from pyspark3d import get_spark_session
-    >>> from pyspark3d import load_user_conf
     >>> from pyspark3d.geometryObjects import Point3D
     >>> from pyspark3d_conf import path_to_conf
     >>> from pyspark3d.spatial3DRDD import Point3DRDD
-
-    Load the user configuration, and initialise the spark session.
-    >>> dic = load_user_conf()
-    >>> spark = get_spark_session(dicconf=dic)
 
     Load the raw data (spherical coordinates)
     >>> fn = os.path.join(path_to_conf, "../src/test/resources/astro_obs.fits")
@@ -295,14 +277,8 @@ def CrossMatchCenter(
 
     Examples
     ----------
-    >>> from pyspark3d import get_spark_session
-    >>> from pyspark3d import load_user_conf
     >>> from pyspark3d_conf import path_to_conf
     >>> from pyspark3d.spatial3DRDD import Point3DRDD
-
-    Load the user configuration, and initialise the spark session.
-    >>> dic = load_user_conf()
-    >>> spark = get_spark_session(dicconf=dic)
 
     Load the raw data (spherical coordinates)
     >>> fn = os.path.join(path_to_conf,
@@ -391,14 +367,8 @@ def CrossMatchHealpixIndex(
 
     Examples
     ----------
-    >>> from pyspark3d import get_spark_session
-    >>> from pyspark3d import load_user_conf
     >>> from pyspark3d_conf import path_to_conf
     >>> from pyspark3d.spatial3DRDD import Point3DRDD
-
-    Load the user configuration, and initialise the spark session.
-    >>> dic = load_user_conf()
-    >>> spark = get_spark_session(dicconf=dic)
 
     Load the raw data (spherical coordinates)
     >>> fn = os.path.join(path_to_conf,
@@ -456,6 +426,14 @@ if __name__ == "__main__":
     if np.__version__ >= "1.14.0":
         np.set_printoptions(legacy="1.13")
 
+    from pyspark3d import get_spark_session
+    from pyspark3d import load_user_conf
+
+    # Load the spark3D JAR+deps, and initialise the spark session.
+    # In a pyspark shell, you do not need this.
+    dic = load_user_conf()
+    spark = get_spark_session(dicconf=dic)
+
     # Run the test suite
-    failure_count, test_count = doctest.testmod()
+    failure_count, test_count = doctest.testmod(extraglobs={"spark": spark})
     sys.exit(failure_count)

--- a/runners/launch_pyspark.sh
+++ b/runners/launch_pyspark.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Run `sbt 'set test in assembly := {}' ++2.11.8 assembly` to get the JAR
+JARS=../target/scala-2.11/spark3D-assembly-0.2.1.jar
+
+# Octree - no part
+ spark-submit --jars $JARS \
+   ../examples/python/collapse_functions.py \
+   -inputpath "/Users/julien/Documents/workspace/data/nbody/velocity_field_20_flat.fits" \
+   -hdu 1 -part OCTREE -npart 10000 --plot
+
+exit
+
+## Other pyspark scripts -- remove the exit above.
+
+# Onion - no part
+spark-submit --jars $JARS \
+  ../examples/python/pyspark3d_onion_part.py \
+  -inputpath "../src/test/resources/astro_obs.fits" \
+  -hdu 1 -npart 10 --plot
+
+# Onion
+spark-submit --jars $JARS \
+  ../examples/python/pyspark3d_onion_part.py \
+  -inputpath "../src/test/resources/astro_obs.fits" \
+  -hdu 1 -part LINEARONIONGRID -npart 10 --plot
+
+# Octree - no part
+spark-submit --jars $JARS \
+  ../examples/python/pyspark3d_octree_part.py \
+  -inputpath "../src/test/resources/cartesian_spheres.fits" \
+  -hdu 1 -npart 10 --plot
+
+# Octree
+spark-submit --jars $JARS \
+  ../examples/python/pyspark3d_octree_part.py \
+  -inputpath "../src/test/resources/cartesian_spheres.fits" \
+  -hdu 1 -part OCTREE -npart 10 --plot


### PR DESCRIPTION
There was some confusion on when and why using `get_spark_session` and `load_user_conf`.
These routines are mainly used in 2 contexts:
  - Running the test suite
  - Using spark3D within a standard ipython or notebook session

In those two cases, you need to load the JAR+deps _within_ the session.

However, in a regular pyspark session, or in batch mode, you should not use it.
Instead, link spark3D when starting the session:
```bash
pyspark --jars /path/to/spar3djar --master ...
# or
spark-submit --jars /path/to/spar3djar --master ...
```

If you installed pyspark3d via pip, the JAR is released with the
python source files. To find its location:
```
python -c "import pyspark3d; print(pyspark3d.__file__)"
```

The doctests have been simplified by using `extraglobs`.