### PR TITLE
Fix wrong angle definition in cartesian to spherical coordinate change!

### DIFF
--- a/src/main/scala/com/spark3d/utils/Utils.scala
+++ b/src/main/scala/com/spark3d/utils/Utils.scala
@@ -44,8 +44,8 @@ object Utils {
     }
 
     val r = math.sqrt(p.x*p.x + p.y*p.y + p.z*p.z)
-    val theta = math.acos(p.z / r)
-    val phi = math.atan(p.y / p.x)
+    val theta = math.atan2(math.sqrt(p.x*p.x + p.y*p.y), p.z)
+    val phi = math.atan2(p.y, p.x)
 
     // Return the new point in spherical coordinates
     new Point3D(r, theta, phi, true)


### PR DESCRIPTION
Bug fix in `cartesianToSpherical`. Following definition [here](https://en.wikipedia.org/wiki/List_of_common_coordinate_transformations#3-dimensional) and [here](http://lampwww.epfl.ch/~hmiller/scaladoc/library/scala/math/package.html), one should use `atan2` and not `acos` or `atan`.

The astropy [code](https://github.com/astropy/astropy/blob/v3.0.x/astropy/coordinates/representation.py#L1803) is pretty useful as well.