### PR TITLE
Compiling against Apache Spark 2.3.2: fix incompatibilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,8 +43,8 @@ lazy val root = (project in file(".")).
    // assemblyShadeRules in assembly := Seq(ShadeRule.rename("nom.**" -> "new_nom.@1").inAll),
    // Put dependencies of the library
    libraryDependencies ++= Seq(
-     "org.apache.spark" %% "spark-core" % "2.1.0" % "provided",
-     "org.apache.spark" %% "spark-sql" % "2.1.0" % "provided",
+     "org.apache.spark" %% "spark-core" % "2.3.2" % "provided",
+     "org.apache.spark" %% "spark-sql" % "2.3.2" % "provided",
      // For loading FITS files
      "com.github.astrolabsoftware" %% "spark-fits" % "0.7.0",
      // "org.datasyslab" % "geospark" % "1.1.3",

--- a/src/main/scala/com/spark3d/utils/Utils.scala
+++ b/src/main/scala/com/spark3d/utils/Utils.scala
@@ -171,6 +171,6 @@ object Utils {
     val ordering = new GuavaOrdering[T] {
       override def compare(l: T, r: T): Int = ord.compare(l, r)
     }
-    ordering.leastOf(input.asJava, num).iterator.asScala
+    ordering.leastOf(input.toIterable.asJava, num).iterator.asScala
   }
 }


### PR DESCRIPTION
### What this PR brings?

Recent version of Spark changed the input type (Iterator -> Iterable) for `ordering.leastOf`. The code now reads (`utils/Utils.scala`):

```scala
private def takeOrdered[T](input: Iterator[T], num: Int)(implicit ord: Ordering[T]): Iterator[T] = {
    val ordering = new GuavaOrdering[T] {
      override def compare(l: T, r: T): Int = ord.compare(l, r)
    }
    ordering.leastOf(input.toIterable.asJava, num).iterator.asScala
  }
```

### How this has been tested?

Unit tests pass.