### PR TITLE
Introducing KNN + DataFrame API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
 install:
   # Download spark 2.3.1
   - "[ -f spark ] || mkdir spark && cd spark && axel http://www-us.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz && cd .."
-  - tar -xf ./spark/spark-2.3.1-bin-hadoop2.7.tgz
-  - export SPARK_HOME=`pwd`/spark-2.3.1-bin-hadoop2.7
+  - tar -xf ./spark/spark-2.4.0-bin-hadoop2.7.tgz
+  - export SPARK_HOME=`pwd`/spark-2.4.0-bin-hadoop2.7
   - echo "spark.yarn.jars=$SPARK_HOME/jars/*.jar" > $SPARK_HOME/conf/spark-defaults.conf
 
   # Install Python deps.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 install:
   # Download spark 2.3.1
-  - "[ -f spark ] || mkdir spark && cd spark && axel http://www-us.apache.org/dist/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && cd .."
+  - "[ -f spark ] || mkdir spark && cd spark && axel http://www-us.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz && cd .."
   - tar -xf ./spark/spark-2.3.1-bin-hadoop2.7.tgz
   - export SPARK_HOME=`pwd`/spark-2.3.1-bin-hadoop2.7
   - echo "spark.yarn.jars=$SPARK_HOME/jars/*.jar" > $SPARK_HOME/conf/spark-defaults.conf

--- a/build.sbt
+++ b/build.sbt
@@ -43,8 +43,8 @@ lazy val root = (project in file(".")).
    // assemblyShadeRules in assembly := Seq(ShadeRule.rename("nom.**" -> "new_nom.@1").inAll),
    // Put dependencies of the library
    libraryDependencies ++= Seq(
-     "org.apache.spark" %% "spark-core" % "2.3.2" % "provided",
-     "org.apache.spark" %% "spark-sql" % "2.3.2" % "provided",
+     "org.apache.spark" %% "spark-core" % "2.4.0" % "provided",
+     "org.apache.spark" %% "spark-sql" % "2.4.0" % "provided",
      // For loading FITS files
      "com.github.astrolabsoftware" %% "spark-fits" % "0.7.1",
      // "org.datasyslab" % "geospark" % "1.1.3",

--- a/docs/04_query_python.md
+++ b/docs/04_query_python.md
@@ -5,4 +5,91 @@ title: "Tutorial: Query, cross-match, play!"
 date: 2018-06-18 22:31:13 +0200
 ---
 
-Under construction
+# Tutorial: Query, cross-match, play!
+
+The spark3D library contains a number of methods and tools to manipulate 3D RDD. Currently, you can already play with *window query*, *KNN* and *cross-match between data sets*.
+
+## Neighbour search
+
+### Standard KNN
+
+Finds the K nearest neighbours of an object within a `DataFrame`.
+The naive implementation here searches through all the the objects in the
+DataFrame to get the KNN. The nearness of the objects here is decided on the
+basis of the distance between their centers.
+
+```python
+from pyspark3d.queries import knn
+
+# Let's suppose we have a DataFrame containing at least
+# 3 columns x, y, z corresponding to cartesian coordinate of points.
+df = spark.read\
+  .format("csv")\
+  .option("header", True)\
+  .option("inferSchema", True)\
+  .load("src/test/resources/cartesian_spheres_manual.csv")
+
+df.show()
+  +---+---+---+------+
+  |  x|  y|  z|radius|
+  +---+---+---+------+
+  |1.0|1.0|1.0|   0.8|
+  |1.0|1.0|1.0|   0.5|
+  |3.0|1.0|1.0|   0.8|
+  |3.0|1.0|1.0|   0.5|
+  |3.0|3.0|1.0|   0.8|
+  |3.0|3.0|1.0|   0.5|
+  |1.0|3.0|1.0|   0.8|
+  |1.0|3.0|1.0|   0.5|
+  |1.0|1.0|3.0|   0.8|
+  |1.0|1.0|3.0|   0.5|
+  |3.0|1.0|3.0|   0.8|
+  |3.0|1.0|3.0|   0.5|
+  |3.0|3.0|3.0|   0.8|
+  |3.0|3.0|3.0|   0.5|
+  |1.0|3.0|3.0|   0.8|
+  |2.0|2.0|2.0|   2.0|
+  +---+---+---+------+
+
+# Define your target for which you want the neighbour points
+coordSys = "cartesian"
+target = [0.2, 0.2, 0.2]
+
+# Number of neighbours
+K = 2
+
+# Return a DataFrame
+dfNeighbour = knn(df.select("x", "y", "z"), target, K, coordSys, unique=False)
+dfNeighbour.show()
+  +---+---+---+
+  |  x|  y|  z|
+  +---+---+---+
+  |1.0|1.0|1.0|
+  |1.0|1.0|1.0|
+  +---+---+---+
+
+# In case you want also the metadata, you can perform a join with initial DataFrame:
+dfNeighbourWithMeta = df.join(dfNeighbour, ["x", "y", "z"], "left_semi")
+dfNeighbourWithMeta.show()
+  +---+---+---+------+
+  |  x|  y|  z|radius|
+  +---+---+---+------+
+  |1.0|1.0|1.0|   0.8|
+  |1.0|1.0|1.0|   0.5|
+  +---+---+---+------+
+```
+
+Note that by default (`unique=False`), the method `knn` will return exactly `K` neighbours
+regardless their values. But there could be neighbours at the same location. If you want exactly `K` distinct neighbours, then choose `unique=True`.
+
+### Accelerated KNN
+
+To come
+
+## Window Query
+
+To come
+
+## Cross-match
+
+To come

--- a/docs/04_query_scala.md
+++ b/docs/04_query_scala.md
@@ -5,4 +5,91 @@ title: "Tutorial: Query, cross-match, play!"
 date: 2018-06-18 22:31:13 +0200
 ---
 
-Under construction
+# Tutorial: Query, cross-match, play!
+
+The spark3D library contains a number of methods and tools to manipulate 3D RDD. Currently, you can already play with *window query*, *KNN* and *cross-match between data sets*.
+
+## Neighbour search
+
+### Standard KNN
+
+Finds the K nearest neighbours of an object within a `DataFrame`.
+The naive implementation here searches through all the the objects in the
+DataFrame to get the KNN. The nearness of the objects here is decided on the
+basis of the distance between their centers.
+
+```scala
+import import com.astrolabsoftware.spark3d.Queries.KNN
+
+// Let's suppose we have a DataFrame containing at least
+// 3 columns x, y, z corresponding to cartesian coordinate of points.
+val df = spark.read
+  .format("csv")
+  .option("header", true)
+  .option("inferSchema", true)
+  .load("src/test/resources/cartesian_spheres_manual.csv")
+
+df.show()
+  +---+---+---+------+
+  |  x|  y|  z|radius|
+  +---+---+---+------+
+  |1.0|1.0|1.0|   0.8|
+  |1.0|1.0|1.0|   0.5|
+  |3.0|1.0|1.0|   0.8|
+  |3.0|1.0|1.0|   0.5|
+  |3.0|3.0|1.0|   0.8|
+  |3.0|3.0|1.0|   0.5|
+  |1.0|3.0|1.0|   0.8|
+  |1.0|3.0|1.0|   0.5|
+  |1.0|1.0|3.0|   0.8|
+  |1.0|1.0|3.0|   0.5|
+  |3.0|1.0|3.0|   0.8|
+  |3.0|1.0|3.0|   0.5|
+  |3.0|3.0|3.0|   0.8|
+  |3.0|3.0|3.0|   0.5|
+  |1.0|3.0|3.0|   0.8|
+  |2.0|2.0|2.0|   2.0|
+  +---+---+---+------+
+
+// Define your target for which you want the neighbour points
+val coordSys : String = "cartesian"
+val target : List[Double] = List(0.2, 0.2, 0.2)
+
+// Number of neighbours
+val K : Int = 2
+
+// Return a DataFrame
+val dfNeighbour = KNN(df.select("x", "y", "z"), target, K, coordSys, unique = false)
+dfNeighbour.show()
+  +---+---+---+
+  |  x|  y|  z|
+  +---+---+---+
+  |1.0|1.0|1.0|
+  |1.0|1.0|1.0|
+  +---+---+---+
+
+// In case you want also the metadata, you can perform a join with initial DataFrame:
+val dfNeighbourWithMeta = df.join(dfNeighbour, Seq("x", "y", "z"), "left_semi")
+dfNeighbourWithMeta.show()
+  +---+---+---+------+
+  |  x|  y|  z|radius|
+  +---+---+---+------+
+  |1.0|1.0|1.0|   0.8|
+  |1.0|1.0|1.0|   0.5|
+  +---+---+---+------+
+```
+
+Note that by default (`unique = false`), the method `KNN` will return exactly `K` neighbours
+regardless their values. But there could be neighbours at the same location. If you want exactly `K` distinct neighbours, then choose `unique = true`.
+
+### Accelerated KNN
+
+To come
+
+## Window Query
+
+To come
+
+## Cross-match
+
+To come

--- a/pyspark3d/checkers.py
+++ b/pyspark3d/checkers.py
@@ -70,10 +70,6 @@ def checkLoadBalancing(df: DataFrame, kind: str="frac", numberOfElements: int=-1
     scalapath = "{}.Checkers.checkLoadBalancing".format(prefix)
     scalaclass = load_from_jvm(scalapath)
 
-    # To convert python dic to Scala Map
-    convpath = "{}.python.PythonClassTag.javaHashMaptoscalaMap".format(prefix)
-    conv = load_from_jvm(convpath)
-
     dfout = _java2py(
         get_spark_context(),
         scalaclass(df._jdf, kind, numberOfElements))

--- a/pyspark3d/examples/knn.py
+++ b/pyspark3d/examples/knn.py
@@ -1,0 +1,115 @@
+# Copyright 2018 AstroLab Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pyspark.sql import SparkSession
+
+import numpy as np
+import pylab as pl
+
+from pyspark3d import set_spark_log_level
+from pyspark3d.visualisation import scatter3d_mpl, sph2cart
+from pyspark3d.queries import knn
+from pyspark3d.repartitioning import addSPartitioning, repartitionByCol
+
+import argparse
+
+def addargs(parser):
+    """ Parse command line arguments for knn """
+
+    ## Arguments
+    parser.add_argument(
+        '-inputpath', dest='inputpath',
+        required=True,
+        help='Path to a FITS file')
+
+    ## Arguments
+    parser.add_argument(
+        '-hdu', dest='hdu',
+        required=True,
+        help='HDU index to load.')
+
+    ## Arguments
+    parser.add_argument(
+        '-part', dest='part',
+        default=None,
+        help='Type of partitioning')
+
+    ## Arguments
+    parser.add_argument(
+        '-npart', dest='npart',
+        default=10,
+        type=int,
+        help='Number of partition')
+
+    ## Arguments
+    parser.add_argument(
+        '--cartesian', dest='cartesian',
+        action="store_true",
+        help='Coordinate system')
+
+
+if __name__ == "__main__":
+    """
+    Perform distributed KNN search
+    """
+    parser = argparse.ArgumentParser(
+        description="""
+        Perform distributed KNN search
+        """)
+    addargs(parser)
+    args = parser.parse_args(None)
+
+    # Initialise Spark Session
+    spark = SparkSession.builder\
+        .appName("collapse")\
+        .getOrCreate()
+
+    # Set logs to be quiet
+    set_spark_log_level()
+
+    # Load raw data
+    fn = args.inputpath
+    df = spark.read.format("fits").option("hdu", 1).load(fn)
+
+    # Perform the re-partitioning, and convert to Python RDD
+    npart = args.npart
+    gridtype = args.part
+    if args.cartesian:
+        coordSys = "cartesian"
+    else:
+        coordSys = "spherical"
+
+    if gridtype is not None:
+
+        options = {
+    	   "geometry": "points",
+           "colnames": "x,y,z",
+           "coordSys": coordSys,
+           "gridtype": gridtype}
+
+        df_colid = addSPartitioning(df, options, npart)
+        df = repartitionByCol(df_colid, "partition_id", True, npart)
+
+    xyz = np.transpose(df.select("x", "y", "z").collect())
+
+    k = 100
+    target = [0.2, 0.2, 0.2]
+    nei = knn(df.select("x", "y", "z"), target, k, coordSys, False)
+
+    xyz = np.transpose(nei.collect())
+
+    ax = scatter3d_mpl(xyz[0], xyz[1], xyz[2], **{"facecolors":"red"})
+    ax3 = scatter3d_mpl(target[0], target[1], target[2], axIn=ax, **{"facecolors":"green"})
+
+    pl.savefig("knn.png")
+    pl.show()

--- a/pyspark3d/examples/run_knn.sh
+++ b/pyspark3d/examples/run_knn.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Raw
+spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
+  knn.py -inputpath "../../src/test/resources/cartesian_spheres.fits" \
+  -hdu 1 --cartesian
+
+# With Octree
+spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
+  knn.py -inputpath "../../src/test/resources/cartesian_spheres.fits" \
+  -hdu 1 -part "octree" -npart 10 --cartesian

--- a/pyspark3d/examples/run_knn.sh
+++ b/pyspark3d/examples/run_knn.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
 # Raw
-spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
-  knn.py -inputpath "../../src/test/resources/cartesian_spheres.fits" \
-  -hdu 1 --cartesian
+fn="../../src/test/resources/cartesian_spheres.fits"
+fn="../../src/test/resources/cartesian_spheres_manual_knn.csv"
 
-# With Octree
 spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
-  knn.py -inputpath "../../src/test/resources/cartesian_spheres.fits" \
-  -hdu 1 -part "octree" -npart 10 --cartesian
+  knn.py -inputpath ${fn} \
+  -hdu 1 -K 2 -target 0.2 0.2 0.2 --cartesian
+
+# # With Octree
+spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
+  knn.py -inputpath ${fn} \
+  -hdu 1 -part "octree" -npart 10 -K 2 -target 0.2 0.2 0.2 --cartesian

--- a/pyspark3d/queries.py
+++ b/pyspark3d/queries.py
@@ -1,0 +1,72 @@
+# Copyright 2018 AstroLab Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pyspark.mllib.common import _java2py
+from pyspark.sql import DataFrame
+
+from pyspark3d import load_from_jvm
+from pyspark3d import get_spark_context
+
+def knn(df: DataFrame, p: list, k: int, coordSys: str, unique: bool):
+    """ Finds the K nearest neighbors of the query object.
+
+    The naive implementation here searches through all the the objects in
+    the DataFrame to get the KNN. The nearness of the objects here
+    is decided on the basis of the distance between their centers.
+
+    NOTE: `unique` is bugged...
+
+    Parameters
+    ----------
+    df : DataFrame
+        Input Dataframe. Must have 3 columns corresponding to the
+        coordinate (x, y, z) if cartesian or (r, theta, phi) f spherical.
+    p : list of float
+        Targeted point for which we want neighbors.
+    k : int
+        Number of neighbours
+    coordSys : str
+        Coordinate system: spherical or cartesian
+    unique : bool
+        Boolean. If true, returns only distinct objects. Default is false.
+
+    Returns
+    --------
+    out : DataFrame
+        DataFrame with the coordinates of the k neighbours found.
+
+    Examples
+    --------
+    >>> df = spark.read.format("fits")\
+        .option("hdu", 1)\
+        .load("../src/test/resources/cartesian_points.fits")
+
+    Get the 100 closest neighbours around the point [0.2, 0.2, 0.2]
+    >>> K = 100
+    >>> target = [0.2, 0.2, 0.2]
+    >>> neighbours = knn(df.select("x", "y", "z"), target, K, "spherical")
+
+    >>> print(neighbours.count())
+    100
+    """
+    prefix = "com.astrolabsoftware.spark3d"
+    scalapath = "{}.Queries.KNN".format(prefix)
+    scalaclass = load_from_jvm(scalapath)
+
+    # # To convert python List to Scala Map
+    convpath = "{}.python.PythonClassTag.javaListtoscalaList".format(prefix)
+    conv = load_from_jvm(convpath)
+
+    out = _java2py(get_spark_context() ,scalaclass(df._jdf, conv(p), k, coordSys, unique))
+
+    return out

--- a/pyspark3d/visualisation.py
+++ b/pyspark3d/visualisation.py
@@ -210,7 +210,7 @@ def collapse_rdd_data(
     return rdd.mapPartitions(
         lambda partition: collapse_function(partition, *args))
 
-def scatter3d_mpl(x: list, y: list, z: list, radius: list=None, axIn = None, **kwargs):
+def scatter3d_mpl(x: list, y: list, z: list, radius: list=None, label: str = None, axIn = None, **kwargs):
     """3D scatter plot from matplotlib.
     Invoke show() or save the figure to get the result.
 
@@ -225,6 +225,8 @@ def scatter3d_mpl(x: list, y: list, z: list, radius: list=None, axIn = None, **k
     radius: int/float or list of int/float, optional
         If given, the size of the markers. Can be a single number
         of a list of sizes (of the same length as the coordinates)
+    label : str
+        Add a label for the legend. Default is None.
     axIn : Axes3D
         If provided, overplot. Default is None (new figure).
     kwargs : Dictionary
@@ -246,7 +248,7 @@ def scatter3d_mpl(x: list, y: list, z: list, radius: list=None, axIn = None, **k
         assert len(radius) == len(x), "Wrong size!"
         rad = radius
 
-    ax.scatter(x, y, z, s=rad, **kwargs)
+    ax.scatter(x, y, z, s=rad, label=label, **kwargs)
 
     ax.set_xlabel("X")
     ax.set_ylabel("Y")

--- a/pyspark3d/visualisation.py
+++ b/pyspark3d/visualisation.py
@@ -14,8 +14,6 @@
 import os
 
 import numpy as np
-import pylab as pl
-from mpl_toolkits.mplot3d import Axes3D
 
 from typing import Iterator, Any, Callable, Generator
 
@@ -212,7 +210,7 @@ def collapse_rdd_data(
     return rdd.mapPartitions(
         lambda partition: collapse_function(partition, *args))
 
-def scatter3d_mpl(x: list, y: list, z: list, radius: list=None, axIn: Axes3D = None, **kwargs) -> Axes3D:
+def scatter3d_mpl(x: list, y: list, z: list, radius: list=None, axIn = None, **kwargs):
     """3D scatter plot from matplotlib.
     Invoke show() or save the figure to get the result.
 
@@ -227,9 +225,15 @@ def scatter3d_mpl(x: list, y: list, z: list, radius: list=None, axIn: Axes3D = N
     radius: int/float or list of int/float, optional
         If given, the size of the markers. Can be a single number
         of a list of sizes (of the same length as the coordinates)
+    axIn : Axes3D
+        If provided, overplot. Default is None (new figure).
+    kwargs : Dictionary
+        Additional key/value for the plot (color, etc...)
 
     """
     if axIn is None:
+        import pylab as pl
+        from mpl_toolkits.mplot3d import Axes3D
         fig = pl.figure()
         ax = Axes3D(fig)
     else:

--- a/pyspark3d/visualisation.py
+++ b/pyspark3d/visualisation.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 import os
 
+import numpy as np
+import pylab as pl
+from mpl_toolkits.mplot3d import Axes3D
+
 from typing import Iterator, Any, Callable, Generator
 
 from py4j.java_gateway import JavaObject
@@ -208,7 +212,7 @@ def collapse_rdd_data(
     return rdd.mapPartitions(
         lambda partition: collapse_function(partition, *args))
 
-def scatter3d_mpl(x: list, y: list, z: list, radius: list=None):
+def scatter3d_mpl(x: list, y: list, z: list, radius: list=None, axIn: Axes3D = None, **kwargs) -> Axes3D:
     """3D scatter plot from matplotlib.
     Invoke show() or save the figure to get the result.
 
@@ -225,11 +229,11 @@ def scatter3d_mpl(x: list, y: list, z: list, radius: list=None):
         of a list of sizes (of the same length as the coordinates)
 
     """
-    import pylab as pl
-    from mpl_toolkits.mplot3d import Axes3D
-
-    fig = pl.figure()
-    ax = Axes3D(fig)
+    if axIn is None:
+        fig = pl.figure()
+        ax = Axes3D(fig)
+    else:
+        ax = axIn
 
     # Size of the centroids
     if radius is None:
@@ -238,12 +242,77 @@ def scatter3d_mpl(x: list, y: list, z: list, radius: list=None):
         assert len(radius) == len(x), "Wrong size!"
         rad = radius
 
-    ax.scatter(x, y, z, c=z, s=rad)
+    ax.scatter(x, y, z, s=rad, **kwargs)
 
     ax.set_xlabel("X")
     ax.set_ylabel("Y")
     ax.set_zlabel("Z")
 
+    return ax
+
+def sph2cart(r: float, theta: float, phi: float) -> (float, float, float):
+    """ Conversion from spherical to cartesian
+
+    Parameters
+    ----------
+    r : float
+        Radial distance (>= 0)
+    theta : float
+        Polar angle in radian (0 <= theta <= np.pi)
+    r : float
+        Azimuthal angle in radian (0 <= phi <= 2 * np.pi)
+
+    Returns
+    ----------
+    x : float
+        Cartesian X in units of r
+    y : float
+        Cartesian Y in units of r
+    z : float
+        Cartesian Z in units of r
+
+    Examples
+    ----------
+    >>> p = sph2cart(1.0, 0.0, 0.0)
+    >>> print(p)
+    (0.0, 0.0, 1.0)
+    """
+    x = r * np.sin(theta) * np.cos(phi)
+    y = r * np.sin(theta) * np.sin(phi)
+    z = r * np.cos(theta)
+    return x, y, z
+
+def cart2sph(x, y, z):
+    """ Conversion from cartesian to spherical
+
+    Parameters
+    ----------
+    x : float
+        Cartesian X
+    y : float
+        Cartesian Y
+    z : float
+        Cartesian Z
+
+    Returns
+    ----------
+    r : float
+        Radial distance (>= 0) in the units of (X, Y, Z)
+    theta : float
+        Polar angle in radian (0 <= theta <= np.pi)
+    r : float
+        Azimuthal angle in radian (0 <= phi <= 2 * np.pi)
+
+    Examples
+    ----------
+    >>> p = cart2sph(0.0, 0.0, 1.0)
+    >>> print(p)
+    (1.0, 0.0, 0.0)
+    """
+    r = np.sqrt(x*x + y*y + z*z)
+    theta = np.arctan2(np.sqrt(x*x + y*y), z)
+    phi = np.arctan2(y, x)
+    return r, theta, phi
 
 if __name__ == "__main__":
     """

--- a/src/main/scala/com/spark3d/Queries.scala
+++ b/src/main/scala/com/spark3d/Queries.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 AstroLab Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.astrolabsoftware.spark3d
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SparkSession
+// import org.apache.spark.sql.functions.udf
+// import org.apache.spark.sql.functions.col
+// import org.apache.spark.sql.functions.lit
+import scala.collection.JavaConverters._
+
+import com.astrolabsoftware.spark3d.geometryObjects.Point3D
+import com.astrolabsoftware.spark3d.spatialOperator.KNN.KNNStandard
+
+
+/**
+  * Main object containing methods to query 3D data sets.
+  */
+object Queries {
+
+  /**
+    * Finds the K nearest neighbors of the query object.
+    * The naive implementation here searches through all the the objects in
+    * the DataFrame to get the KNN. The nearness of the objects here
+    * is decided on the basis of the distance between their centers.
+    *
+    * @param df : Input DataFrame. Must have 3 columns (the coordinate center of objects)
+    * @param target : List of 3 Double. The coordinates of the targeted point.
+    * @param k : Integer, number of neighbours to find.
+    * @param coordSys : String, coordinate system of the points: spherical or cartesian
+    * @param unique : Boolean. If true, returns only distinct objects. Default is false.
+    * @return DataFrame with the coordinates of the k neighbours found.
+    */
+  def KNN(df: DataFrame, target: List[Double], k : Int, coordSys: String, unique: Boolean = false) : DataFrame = {
+    // Number of coordinates must be 3
+    val ok = df.columns.size match {
+      case 3 => true
+      case _ => throw new AssertionError("""
+        Input DataFrame must have 3 columns to perform KNN (the coordinate center of objects).
+        Use df.select("col1", "col2", "col3")
+      """)
+    }
+
+    // Definition of the coordinate system. Spherical or cartesian
+    val isSpherical : Boolean = coordSys match {
+      case "spherical" => true
+      case "cartesian" => false
+      case _ => throw new AssertionError("""
+        Coordinate system not understood! You must choose between:
+        spherical, cartesian
+        """)
+    }
+
+    // Assume 3 columns have the same dtype.
+    val inputType = df.dtypes(0)._2
+
+    // Map to coordinates to Point3D. Must be Double.
+    val rdd = inputType match {
+      case "DoubleType" => df.rdd.map(x => new Point3D(x.getDouble(0), x.getDouble(1), x.getDouble(2), isSpherical))
+      case "FloatType" => df.rdd.map(x => new Point3D(x.getFloat(0).toDouble, x.getFloat(1).toDouble, x.getFloat(2).toDouble, isSpherical))
+      case "IntegerType" => df.rdd.map(x => new Point3D(x.getInt(0).toDouble, x.getInt(1).toDouble, x.getInt(2).toDouble, isSpherical))
+    }
+
+    // Map target to Point3D
+    val targetAsPoint = new Point3D(target(0), target(1), target(2), isSpherical)
+
+    // Perform the KNN search - return an array of Point3D
+    val out = KNNStandard(rdd, targetAsPoint, k, unique)
+      // Get the coordinates of points
+      .map(x => x.getCoordinate)
+      // map to Tuple
+      .map(x => (x(0), x(1), x(2)))
+
+    // Load Spark implicits
+    val locSpark = SparkSession.getActiveSession.get
+    import locSpark.implicits._
+
+    // Return a DataFrame
+    locSpark.sparkContext.parallelize(out).toDF(df.columns(0), df.columns(1), df.columns(2))
+  }
+}

--- a/src/main/scala/com/spark3d/Repartitioning.scala
+++ b/src/main/scala/com/spark3d/Repartitioning.scala
@@ -15,8 +15,6 @@
  */
 package com.astrolabsoftware.spark3d
 
-import java.util.HashMap
-
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.functions.col

--- a/src/main/scala/com/spark3d/python/PythonClassTag.scala
+++ b/src/main/scala/com/spark3d/python/PythonClassTag.scala
@@ -80,4 +80,23 @@ object PythonClassTag {
   def javaHashMaptoscalaMap(hashMap: HashMap[String, String]): Map[String, String] = {
     hashMap.asScala.toMap
   }
+
+  /**
+    * By default, Python lists are converted in java.util.ArrayList when
+    * used as method arguments by py4j. This is a problem for most Scala methods
+    * which need List as arguments.
+    *
+    * This method allows the conversion from Python list to scala immutable List in py4j.
+    * This should be use in Python as:
+    * mylist = [val, ...]
+    * conv = sc._jvm.com.astrolabsoftware.spark3d.python.PythonClassTag.javaListtoscalaList
+    * scalaList = conv(mylist)
+    * sc._jvm.<...>.myscalaMethod(scalaList)
+    *
+    * @param javaArrayList : java.util.ArrayList[Double]
+    * @return List[Double]
+    */
+  def javaListtoscalaList(javaArrayList: java.util.ArrayList[Double]): List[Double] = {
+    javaArrayList.asScala.toList
+  }
 }

--- a/src/main/scala/com/spark3d/spatialOperator/KNN.scala
+++ b/src/main/scala/com/spark3d/spatialOperator/KNN.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 AstroLab Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.astrolabsoftware.spark3d.spatialOperator
+
+import com.astrolabsoftware.spark3d.geometryObjects.Point3D
+import com.astrolabsoftware.spark3d.geometryObjects.Shape3D.Shape3D
+import com.astrolabsoftware.spark3d.utils.GeometryObjectComparator
+import com.astrolabsoftware.spark3d.utils.Utils.takeOrdered
+import com.astrolabsoftware.spark3d.spatialPartitioning._
+
+import org.apache.spark.rdd.RDD
+
+import scala.collection.mutable.{HashSet, ListBuffer}
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+import scala.util.control.Breaks._
+
+object KNN {
+
+  /**
+    * Finds the K nearest neighbors of the query object.
+    * The naive implementation here searches through all the the objects in
+    * the RDD to get the KNN. The nearness of the objects here
+    * is decided on the basis of the distance between their centers.
+    *
+    * @param rdd : RDD[T]
+    *   RDD of T (T<:Shape3D)
+    * @param queryObject : (T<:Shape3D)
+    *   Object to which the KNN are to be found
+    * @param k : (Int)
+    *   Number of nearest neighbors requested
+    * @param unique : (Boolean)
+          If True, returns only distinct objects. Default is false.
+    * @return (List[T]) List of the KNN T<:Shape3D.
+    *
+    */
+  def KNNStandard[T <: Shape3D: ClassTag](
+      rdd: RDD[T], queryObject: T,
+      k: Int, unique: Boolean = false): List[T] = {
+    val knn = takeOrdered[T](rdd, k, queryObject, unique)(
+      new GeometryObjectComparator[T](queryObject.center)
+    )
+    knn.toList
+  }
+}

--- a/src/main/scala/com/spark3d/utils/BoundedUniquePriorityQueue.scala
+++ b/src/main/scala/com/spark3d/utils/BoundedUniquePriorityQueue.scala
@@ -75,7 +75,9 @@ class BoundedUniquePriorityQueue[A <: Shape3D](maxSize: Int)(implicit ord: Order
 
   private def maybeReplaceLowest(a: A): Boolean = {
     val head = underlying.head
-    if (head != null && ord.gt(a, head)) {
+    // Definition of scala.Ordering.get(x, y) is:
+    // Returns true iff y comes before x in the ordering and is not the same as x.
+    if (head != null && ord.gt(head, a)) {
       underlying.dequeue
       underlying.enqueue(a)
       containedElements.add(a.center.getCoordinate.hashCode)

--- a/src/test/scala/com/spark3d/QueriesTest.scala
+++ b/src/test/scala/com/spark3d/QueriesTest.scala
@@ -55,6 +55,7 @@ class QueriesTest extends FunSuite with BeforeAndAfterAll {
 
   val fn_cart = "src/test/resources/cartesian_spheres.fits"
   val fn_sphe = "src/test/resources/astro_obs.fits"
+  val fn_sphe_manual = "src/test/resources/cartesian_spheres_manual_knn.csv"
 
   test("Can you find the K nearest neighbours (cartesian + no unique)?") {
     val spark2 = spark
@@ -208,5 +209,21 @@ class QueriesTest extends FunSuite with BeforeAndAfterAll {
     val knn = KNN(df.select(col("x").cast("double"), col("y").cast("double"), col("z").cast("double")), queryObject, 10, "cartesian", false)
 
     assert(knn.count == 10)
+  }
+
+  test("Can you take Integer as input?") {
+    val spark2 = spark
+    import spark2.implicits._
+
+    val df = spark.read.format("csv")
+      .option("inferSchema", true)
+      .option("header", true)
+      .load(fn_sphe_manual)
+
+    val queryObject = List(0.2, 0.2, 0.2)
+
+    val knn = KNN(df.select(col("x").cast("integer"), col("y").cast("integer"), col("z").cast("integer")), queryObject, 2, "cartesian", false)
+
+    assert(knn.count == 2)
   }
 }

--- a/src/test/scala/com/spark3d/QueriesTest.scala
+++ b/src/test/scala/com/spark3d/QueriesTest.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018 AstroLab Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.astrolabsoftware.spark3d
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+import com.astrolabsoftware.spark3d._
+import com.astrolabsoftware.spark3d.Queries.KNN
+
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.SparkSession
+
+import org.apache.log4j.Level
+import org.apache.log4j.Logger
+
+class QueriesTest extends FunSuite with BeforeAndAfterAll {
+
+  Logger.getLogger("org").setLevel(Level.OFF)
+  Logger.getLogger("akka").setLevel(Level.OFF)
+
+  private val master = "local[2]"
+  private val appName = "spark3dtest"
+
+  private var spark: SparkSession = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    spark = SparkSession
+      .builder()
+      .master(master)
+      .appName(appName)
+      .getOrCreate()
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      spark.sparkContext.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  val fn_cart = "src/test/resources/cartesian_spheres.fits"
+  val fn_sphe = "src/test/resources/astro_obs.fits"
+
+  test("Can you find the K nearest neighbours (cartesian)?") {
+    val spark2 = spark
+    import spark2.implicits._
+
+    val df = spark.read.format("fits")
+      .option("hdu", 1)
+      .load(fn_cart)
+
+    val options = Map(
+      "geometry" -> "points",
+      "colnames" -> "x,y,z",
+      "coordSys" -> "cartesian",
+      "gridtype" -> "octree")
+
+    val dfp_repart = df.addSPartitioning(options, 10).repartitionByCol("partition_id", preLabeled = true)
+
+    val queryObject = 0.2::0.2::0.2::Nil
+
+    // using Octree partitioning
+    val knn = KNN(df.select("x", "y", "z"), queryObject, 5000, options("coordSys"), false)
+    val knnRepart = KNN(dfp_repart.select("x", "y", "z"), queryObject, 5000, options("coordSys"), false)
+    // val knnEff = SpatialQuery.KNNEfficient(pointRDDPart, queryObject, 5000)
+
+    assert(knn.distinct.count == 5000)
+    assert(knnRepart.distinct.count == 5000)
+
+    // Stupid sum to quickly check they are the same
+    assert(knn.select("x").collect().map(x => x.getDouble(0)).sum == knnRepart.select("x").collect().map(x => x.getDouble(0)).sum)
+    // assert(knnEff.map(x=>x.center.getCoordinate).distinct.size == 5000)
+  }
+
+  test("Can you find the K nearest neighbours (spherical)?") {
+    val spark2 = spark
+    import spark2.implicits._
+
+    val df = spark.read.format("fits")
+      .option("hdu", 1)
+      .load(fn_sphe)
+
+    val options = Map(
+      "geometry" -> "points",
+      "colnames" -> "Z_COSMO,RA,DEC",
+      "coordSys" -> "spherical",
+      "gridtype" -> "onion")
+
+    val dfp_repart = df.addSPartitioning(options, 10).repartitionByCol("partition_id", preLabeled = true)
+
+    val queryObject = 0.0::0.0::0.0::Nil
+
+    // using Octree partitioning
+    val knn = KNN(df.select("Z_COSMO", "RA", "DEC"), queryObject, 5000, options("coordSys"), false)
+    val knnRepart = KNN(dfp_repart.select("Z_COSMO", "RA", "DEC"), queryObject, 5000, options("coordSys"), false)
+    // val knnEff = SpatialQuery.KNNEfficient(pointRDDPart, queryObject, 5000)
+
+    assert(knn.distinct.count == 5000)
+    assert(knnRepart.distinct.count == 5000)
+
+    // Stupid sum to quickly check they are the same
+    assert(knn.select("Z_COSMO").collect().map(x => x.getDouble(0)).sum == knnRepart.select("Z_COSMO").collect().map(x => x.getDouble(0)).sum)
+    // assert(knnEff.map(x=>x.center.getCoordinate).distinct.size == 5000)
+  }
+
+  test("Do you have the correct behaviour if K=0?") {
+
+    val spark2 = spark
+    import spark2.implicits._
+
+    val df = spark.read.format("fits")
+      .option("hdu", 1)
+      .load(fn_cart)
+
+    val queryObject = 0.2::0.2::0.2::Nil
+
+    // using Octree partitioning
+    val knn = KNN(df.select("x", "y", "z"), queryObject, 0, "cartesian", false)
+    assert(knn.count == 0)
+  }
+
+  test("Can you catch a wrong DF in input?") {
+    val spark2 = spark
+    import spark2.implicits._
+
+    val df = spark.read.format("fits")
+      .option("hdu", 1)
+      .load(fn_cart)
+
+    val queryObject = 0.2::0.2::0.2::Nil
+
+    val exception = intercept[AssertionError] {
+      KNN(df, queryObject, 10, "cartesian", false)
+    }
+    assert(exception.getMessage.contains("Input DataFrame must have 3 columns to perform KNN"))
+  }
+
+  test("Can you catch a wrong coordSys?") {
+    val spark2 = spark
+    import spark2.implicits._
+
+    val df = spark.read.format("fits")
+      .option("hdu", 1)
+      .load(fn_cart)
+
+    val queryObject = 0.2::0.2::0.2::Nil
+
+    val exception = intercept[AssertionError] {
+      KNN(df.select("x", "y", "z"), queryObject, 10, "toto", false)
+    }
+    assert(exception.getMessage.contains("Coordinate system not understood!"))
+  }
+
+  test("Can you take Float as input?") {
+    val spark2 = spark
+    import spark2.implicits._
+
+    val df = spark.read.format("fits")
+      .option("hdu", 1)
+      .load(fn_cart)
+
+    val queryObject = 0.2::0.2::0.2::Nil
+
+    val knn = KNN(df.select(col("x").cast("double"), col("y").cast("double"), col("z").cast("double")), queryObject, 10, "cartesian", false)
+
+    assert(knn.count == 10)
+  }
+}

--- a/src/test/scala/com/spark3d/python/PythonClassTagTest.scala
+++ b/src/test/scala/com/spark3d/python/PythonClassTagTest.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import com.astrolabsoftware.spark3d.geometryObjects.Point3D
 import com.astrolabsoftware.spark3d.python.PythonClassTag.classTagFromObject
 import com.astrolabsoftware.spark3d.python.PythonClassTag.javaHashMaptoscalaMap
+import com.astrolabsoftware.spark3d.python.PythonClassTag.javaListtoscalaList
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
@@ -89,6 +90,13 @@ class PythonClassTagTest extends FunSuite with BeforeAndAfterAll {
     val scalaMap = javaHashMaptoscalaMap(javaHasMap)
 
     assert(scalaMap.isInstanceOf[Map[String, String]])
+  }
 
+  test("Can you convert a java ArrayList to scala List?") {
+    var javaArrayList = new java.util.ArrayList[Double]
+    javaArrayList.add(0.3)
+    val scalaList = javaListtoscalaList(javaArrayList)
+
+    assert(scalaList.isInstanceOf[List[Double]])
   }
 }


### PR DESCRIPTION
This PR re-introduces the KNN method, but with the DataFrame API.

The core of the routine remains untouched (developed during GSoC 2018 by Mayur, and using RDD), but the I/O are different. It takes a DataFrame as input, and return a DataFrame containing the coordinates of the K nearest neighbours.

Note: the option `unique` seems bugged (i.e. using KNN with `unique=true` produces wrong results). I know that `ordering.leastOf` recently changes its interface (from Scala iterable to Java Iterable) - so I won't be surprised if the meaning changed as well.