### PR TITLE
Fix wrong ordering when using unique in KNN. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
 install:
   # Download spark 2.3.1
   - "[ -f spark ] || mkdir spark && cd spark && axel http://www-us.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz && cd .."
-  - tar -xf ./spark/spark-2.3.1-bin-hadoop2.7.tgz
-  - export SPARK_HOME=`pwd`/spark-2.3.1-bin-hadoop2.7
+  - tar -xf ./spark/spark-2.4.0-bin-hadoop2.7.tgz
+  - export SPARK_HOME=`pwd`/spark-2.4.0-bin-hadoop2.7
   - echo "spark.yarn.jars=$SPARK_HOME/jars/*.jar" > $SPARK_HOME/conf/spark-defaults.conf
 
   # Install Python deps.

--- a/src/main/scala/com/spark3d/utils/BoundedUniquePriorityQueue.scala
+++ b/src/main/scala/com/spark3d/utils/BoundedUniquePriorityQueue.scala
@@ -75,7 +75,9 @@ class BoundedUniquePriorityQueue[A <: Shape3D](maxSize: Int)(implicit ord: Order
 
   private def maybeReplaceLowest(a: A): Boolean = {
     val head = underlying.head
-    if (head != null && ord.gt(a, head)) {
+    // Definition of scala.Ordering.get(x, y) is:
+    // Returns true iff y comes before x in the ordering and is not the same as x.
+    if (head != null && ord.gt(head, a)) {
       underlying.dequeue
       underlying.enqueue(a)
       containedElements.add(a.center.getCoordinate.hashCode)


### PR DESCRIPTION
We are using the wrong convention for `scala.Ordering.get`. From the [doc](https://www.scala-lang.org/api/2.11.8/#scala.math.Ordering) we have

```scala
def gt(x: T, y: T): Boolean
  // Return true if x > y in the ordering.
```

while in the code we had:

```scala
// in BoundedUniquePriorityQueue.scala
if (head != null && ord.gt(a, head)) {
  // replace head by a
}
```

leading to wrong result!

without the fix:

![knn_with_octree_repartitioning](https://user-images.githubusercontent.com/20426972/49077623-00ca0800-f23c-11e8-8dfd-7aa974df9112.png)

With the fix:

![knn_with_octree_repartitioning](https://user-images.githubusercontent.com/20426972/49077516-bd6f9980-f23b-11e8-928d-e817054276c1.png)
