### PR TITLE
Introducing Window Query + DataFrame API

### DIFF
--- a/docs/04_query_python.md
+++ b/docs/04_query_python.md
@@ -69,7 +69,7 @@ dfNeighbour.show()
   +---+---+---+
 
 # In case you want also the metadata, you can perform a join with initial DataFrame:
-dfNeighbourWithMeta = df.join(dfNeighbour, ["x", "y", "z"], "left_semi")
+dfNeighbourWithMeta = df.join(dfNeighbour, dfNeighbour.columns, "left_semi")
 dfNeighbourWithMeta.show()
   +---+---+---+------+
   |  x|  y|  z|radius|
@@ -88,7 +88,91 @@ To come
 
 ## Window Query
 
-To come
+A window query takes as input a `DataFrame` and an envelope, and returns all objects in the RDD intersecting the envelope (contained in and crossing the envelope):
+
+```python
+from pyspark3d.queries import windowquery
+
+# Let's suppose we have a DataFrame containing at least
+# 3 columns x, y, z corresponding to cartesian coordinate of points.
+df = spark.read\
+  .format("csv")\
+  .option("header", True)\
+  .option("inferSchema", True)\
+  .load("src/test/resources/cartesian_spheres_manual.csv")
+
+df.show()
+  +---+---+---+------+
+  |  x|  y|  z|radius|
+  +---+---+---+------+
+  |1.0|1.0|1.0|   0.8|
+  |1.0|1.0|1.0|   0.5|
+  |3.0|1.0|1.0|   0.8|
+  |3.0|1.0|1.0|   0.5|
+  |3.0|3.0|1.0|   0.8|
+  |3.0|3.0|1.0|   0.5|
+  |1.0|3.0|1.0|   0.8|
+  |1.0|3.0|1.0|   0.5|
+  |1.0|1.0|3.0|   0.8|
+  |1.0|1.0|3.0|   0.5|
+  |3.0|1.0|3.0|   0.8|
+  |3.0|1.0|3.0|   0.5|
+  |3.0|3.0|3.0|   0.8|
+  |3.0|3.0|3.0|   0.5|
+  |1.0|3.0|3.0|   0.8|
+  |2.0|2.0|2.0|   2.0|
+  +---+---+---+------+
+
+# Define your envelope - here we take a sphere
+# centered on (2.0, 1.0, 2.0) with radius 1.8
+windowtype = "sphere"
+windowcoord = [2.0, 1.0, 2.0, 1.8]
+coordSys = "cartesian"
+
+# Return a DataFrame
+env = windowquery(df.select("x", "y", "z"), windowtype, windowcoord, coordSys)
+env.show()
+  +---+---+---+
+  |  x|  y|  z|
+  +---+---+---+
+  |1.0|1.0|1.0|
+  |1.0|1.0|1.0|
+  |3.0|1.0|1.0|
+  |3.0|1.0|1.0|
+  |1.0|1.0|3.0|
+  |1.0|1.0|3.0|
+  |3.0|1.0|3.0|
+  |3.0|1.0|3.0|
+  |2.0|2.0|2.0|
+  +---+---+---+
+
+# In case you want also the metadata, you can perform a join with initial DataFrame:
+envWithMeta = df.join(env, env.columns, "left_semi")
+envWithMeta.show()
+  +---+---+---+------+
+  |  x|  y|  z|radius|
+  +---+---+---+------+
+  |3.0|1.0|1.0|   0.8|
+  |3.0|1.0|1.0|   0.5|
+  |3.0|1.0|3.0|   0.8|
+  |3.0|1.0|3.0|   0.5|
+  |2.0|2.0|2.0|   2.0|
+  |1.0|1.0|1.0|   0.8|
+  |1.0|1.0|1.0|   0.5|
+  |1.0|1.0|3.0|   0.8|
+  |1.0|1.0|3.0|   0.5|
+  +---+---+---+------+
+```
+
+Note that the envelope can be anything among the `Shape3D`: point, shell, sphere, box.
+Depending on the `windowtype`, you would express `windowcoord` as:
+- point: `windowcoord` = `[x, y, z]`
+- sphere: `windowcoord` = `[x, y, z, R]`
+- shell: `windowcoord` = `[x, y, z, Rin, Rout]`
+- box: `windowcoord` = `[x1, y1, z1, x2, y2, z2, x3, y3, z3]`
+
+Use `[x, y, z]` for cartesian or `[r, theta, phi]` for spherical.
+Note that box only accepts cartesian coordinates.
 
 ## Cross-match
 

--- a/docs/04_query_scala.md
+++ b/docs/04_query_scala.md
@@ -19,7 +19,7 @@ DataFrame to get the KNN. The nearness of the objects here is decided on the
 basis of the distance between their centers.
 
 ```scala
-import import com.astrolabsoftware.spark3d.Queries.KNN
+import com.astrolabsoftware.spark3d.Queries.KNN
 
 // Let's suppose we have a DataFrame containing at least
 // 3 columns x, y, z corresponding to cartesian coordinate of points.
@@ -69,7 +69,7 @@ dfNeighbour.show()
   +---+---+---+
 
 // In case you want also the metadata, you can perform a join with initial DataFrame:
-val dfNeighbourWithMeta = df.join(dfNeighbour, Seq("x", "y", "z"), "left_semi")
+val dfNeighbourWithMeta = df.join(dfNeighbour, dfNeighbour.columns, "left_semi")
 dfNeighbourWithMeta.show()
   +---+---+---+------+
   |  x|  y|  z|radius|
@@ -88,7 +88,90 @@ To come
 
 ## Window Query
 
-To come
+A window query takes as input a `DataFrame` and an envelope, and returns all objects in the RDD intersecting the envelope (contained in and crossing the envelope):
+
+```scala
+import com.astrolabsoftware.spark3d.Queries.windowQuery
+
+// Let's suppose we have a DataFrame containing at least
+// 3 columns x, y, z corresponding to cartesian coordinate of points.
+val df = spark.read
+  .format("csv")
+  .option("header", true)
+  .option("inferSchema", true)
+  .load("src/test/resources/cartesian_spheres_manual.csv")
+
+df.show()
+  +---+---+---+------+
+  |  x|  y|  z|radius|
+  +---+---+---+------+
+  |1.0|1.0|1.0|   0.8|
+  |1.0|1.0|1.0|   0.5|
+  |3.0|1.0|1.0|   0.8|
+  |3.0|1.0|1.0|   0.5|
+  |3.0|3.0|1.0|   0.8|
+  |3.0|3.0|1.0|   0.5|
+  |1.0|3.0|1.0|   0.8|
+  |1.0|3.0|1.0|   0.5|
+  |1.0|1.0|3.0|   0.8|
+  |1.0|1.0|3.0|   0.5|
+  |3.0|1.0|3.0|   0.8|
+  |3.0|1.0|3.0|   0.5|
+  |3.0|3.0|3.0|   0.8|
+  |3.0|3.0|3.0|   0.5|
+  |1.0|3.0|3.0|   0.8|
+  |2.0|2.0|2.0|   2.0|
+  +---+---+---+------+
+
+// Define your envelope - here we take a sphere
+// centred on (2.0, 1.0, 2.0) with radius 1.8
+val windowtype = "sphere"
+val windowcoord = List(2.0, 1.0, 2.0, 1.8)
+val coordSys = "cartesian"
+
+// Return a DataFrame
+val env = windowQuery(df.select("x", "y", "z"), windowtype, windowcoord, coordSys)
+env.show()
+  +---+---+---+
+  |  x|  y|  z|
+  +---+---+---+
+  |1.0|1.0|1.0|
+  |1.0|1.0|1.0|
+  |3.0|1.0|1.0|
+  |3.0|1.0|1.0|
+  |1.0|1.0|3.0|
+  |1.0|1.0|3.0|
+  |3.0|1.0|3.0|
+  |3.0|1.0|3.0|
+  |2.0|2.0|2.0|
+  +---+---+---+
+// In case you want also the metadata, you can perform a join with initial DataFrame:
+envWithMeta = df.join(env, env.columns, "left_semi")
+envWithMeta.show()
+  +---+---+---+------+
+  |  x|  y|  z|radius|
+  +---+---+---+------+
+  |3.0|1.0|1.0|   0.8|
+  |3.0|1.0|1.0|   0.5|
+  |3.0|1.0|3.0|   0.8|
+  |3.0|1.0|3.0|   0.5|
+  |2.0|2.0|2.0|   2.0|
+  |1.0|1.0|1.0|   0.8|
+  |1.0|1.0|1.0|   0.5|
+  |1.0|1.0|3.0|   0.8|
+  |1.0|1.0|3.0|   0.5|
+  +---+---+---+------+
+```
+
+Note that the envelope can be anything among the `Shape3D`: point, shell, sphere, box.
+Depending on the `windowtype`, you would express `windowcoord` as:
+- point: `windowcoord` = `List(x, y, z)`
+- sphere: `windowcoord` = `List(x, y, z, R)`
+- shell: `windowcoord` = `List(x, y, z, Rin, Rout)`
+- box: `windowcoord` = `List(x1, y1, z1, x2, y2, z2, x3, y3, z3)`
+
+Use `(x, y, z)` for cartesian or `(r, theta, phi)` for spherical.
+Note that box only accepts cartesian coordinates.
 
 ## Cross-match
 

--- a/pyspark3d/examples/run_windowquery.sh
+++ b/pyspark3d/examples/run_windowquery.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Raw
+fn="../../src/test/resources/cartesian_spheres_manual.csv"
+
+spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
+  windowquery.py -inputpath ${fn} \
+  -hdu 1 -windowtype sphere -windowcoord 2.0 1.0 2.0 1.8 --cartesian

--- a/pyspark3d/examples/windowquery.py
+++ b/pyspark3d/examples/windowquery.py
@@ -1,0 +1,169 @@
+# Copyright 2018 AstroLab Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pyspark.sql import SparkSession
+
+import numpy as np
+import pylab as pl
+
+from pyspark3d import set_spark_log_level
+from pyspark3d.visualisation import scatter3d_mpl
+from pyspark3d.queries import windowquery
+
+import argparse
+
+def drawSphere(xc, yc, zc, r):
+    """ Draw a 3D sphere
+
+    Parameters
+    ----------
+    xc : double
+        X coordinate for the center in data units.
+    yc : double
+        Y coordinate for the center in data units.
+    zc : double
+        Z coordinate for the center in data units.
+    r : double
+        Radius of the sphere in data units.
+
+    Returns
+    ----------
+    (x, y, z) : tuple of 1D array
+        x, y, z 1D coordinates of the 3D surface.
+    """
+    u, v = np.mgrid[0: 2 * np.pi: 20j, 0: np.pi: 10j]
+    x = np.cos(u) * np.sin(v)
+    y = np.sin(u) * np.sin(v)
+    z = np.cos(v)
+
+    # shift to the center and scale the sphere
+    x = r * x + xc
+    y = r * y + yc
+    z = r * z + zc
+    return (x,y,z)
+
+def addargs(parser):
+    """ Parse command line arguments for windowquery """
+
+    ## Arguments
+    parser.add_argument(
+        '-inputpath', dest='inputpath',
+        required=True,
+        help='Path to a FITS file')
+
+    ## Arguments
+    parser.add_argument(
+        '-hdu', dest='hdu',
+        required=True,
+        help='HDU index to load.')
+
+    ## Arguments
+    parser.add_argument(
+        '-windowtype', dest='windowtype',
+        required=True,
+        type=str,
+        help='')
+
+    ## Arguments
+    parser.add_argument(
+        '-windowcoord', dest='windowcoord',
+        default=[],
+        nargs='+',
+        type=float,
+        help='')
+
+    ## Arguments
+    parser.add_argument(
+        '--cartesian', dest='cartesian',
+        action="store_true",
+        help='Coordinate system')
+
+
+if __name__ == "__main__":
+    """
+    Perform distributed window query
+    """
+    parser = argparse.ArgumentParser(
+        description="""
+        Perform distributed window query
+        """)
+    addargs(parser)
+    args = parser.parse_args(None)
+
+    # Initialise Spark Session
+    spark = SparkSession.builder\
+        .appName("collapse")\
+        .getOrCreate()
+
+    # Set logs to be quiet
+    set_spark_log_level()
+
+    # Load raw data
+    fn = args.inputpath
+    if fn.endswith(".fits"):
+        df = spark.read.format("fits").option("hdu", 1).load(fn)
+    elif fn.endswith(".csv"):
+        df = spark.read.format("csv").option("inferSchema", True).option("header", True).load(fn)
+    else:
+        print("Input format not understood - choose btw FITS or CSV.")
+
+    # Perform the re-partitioning, and convert to Python RDD
+    windowtype = args.windowtype
+    if args.cartesian:
+        coordSys = "cartesian"
+    else:
+        coordSys = "spherical"
+
+    fnout = "{}_window.png".format(windowtype)
+    title = "{} window".format(windowtype)
+
+    xyz = np.transpose(df.select("x", "y", "z").collect())
+
+    windowcoord = args.windowcoord
+
+    ## Plot the data set
+    all = np.transpose(df.select("x", "y", "z").collect())
+    ax = scatter3d_mpl(
+        all[0], all[1], all[2],
+        radius=np.ones_like(all[0]) * 30,
+        label="Data set", **{"facecolors":"blue", "marker": "+"})
+
+    ## Plot Target
+    if windowtype == "point":
+        assert(len(windowcoord) == 3)
+        radius = [30]
+        scatter3d_mpl(
+            [windowcoord[0]], [windowcoord[1]], [windowcoord[2]],
+            radius=radius, axIn=ax, **{"facecolors":"red", "alpha": 0.3})
+    elif windowtype == "sphere":
+        assert(len(windowcoord) == 4)
+        (xs,ys,zs) = drawSphere(windowcoord[0],windowcoord[1],windowcoord[2],windowcoord[3])
+        ax.plot_surface(xs, ys, zs, color="r", alpha=0.3)
+    elif windowtype == "shell":
+        assert(len(windowcoord) == 5)
+    elif windowtype == "box":
+        assert(len(windowcoord) == 9)
+
+    ## Plot window query
+    env = windowquery(df.select("x", "y", "z"), windowtype, windowcoord, coordSys)
+    xyz = np.transpose(env.collect())
+    radius = np.ones_like(xyz[0]) * 60
+    scatter3d_mpl(
+        xyz[0], xyz[1], xyz[2],
+        label="Objects found",
+        radius=radius, axIn=ax, **{"facecolors":"black"})
+
+    pl.legend()
+    pl.title(title)
+    pl.savefig(fnout)
+    pl.show()

--- a/pyspark3d/queries.py
+++ b/pyspark3d/queries.py
@@ -24,8 +24,6 @@ def knn(df: DataFrame, p: list, k: int, coordSys: str, unique: bool):
     the DataFrame to get the KNN. The nearness of the objects here
     is decided on the basis of the distance between their centers.
 
-    NOTE: `unique` is bugged...
-
     Parameters
     ----------
     df : DataFrame
@@ -54,10 +52,14 @@ def knn(df: DataFrame, p: list, k: int, coordSys: str, unique: bool):
     Get the 100 closest neighbours around the point [0.2, 0.2, 0.2]
     >>> K = 100
     >>> target = [0.2, 0.2, 0.2]
-    >>> neighbours = knn(df.select("x", "y", "z"), target, K, "spherical")
+    >>> unique = False
+    >>> neighbours = knn(df.select("x", "y", "z"), target, K, "spherical", unique)
 
     >>> print(neighbours.count())
     100
+
+    You can add back the metadata
+    >>> neighboursWithMeta = df.join(neighbours, ["x", "y", "z"], "left_semi")
     """
     prefix = "com.astrolabsoftware.spark3d"
     scalapath = "{}.Queries.KNN".format(prefix)
@@ -70,3 +72,121 @@ def knn(df: DataFrame, p: list, k: int, coordSys: str, unique: bool):
     out = _java2py(get_spark_context() ,scalaclass(df._jdf, conv(p), k, coordSys, unique))
 
     return out
+
+def windowquery(df: DataFrame, windowtype: str, windowcoord: int, coordSys: str):
+    """ Perform window query, that is match between DF elements and
+    a user-defined window (point, sphere, shell, box).
+
+    If windowtype =
+        - point: windowcoord = [x, y, z]
+        - sphere: windowcoord = [x, y, z, R]
+        - shell: windowcoord = [x, y, z, Rin, Rout]
+        - box: windowcoord = [x1, y1, z1, x2, y2, z2, x3, y3, z3]
+    Use [x, y, z] for cartesian or [r, theta, phi] for spherical.
+    Note that box only accepts cartesian coordinates.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Input Dataframe. Must have 3 columns corresponding to the
+        coordinate (x, y, z) if cartesian or (r, theta, phi) f spherical.
+    windowtype : str
+        point, shell, sphere, or box.
+    windowcoord : list of float
+        List of Doubles. The coordinates of the window (see doc above).
+    coordSys : str
+        Coordinate system: spherical or cartesian
+
+    Returns
+    --------
+    out : DataFrame
+        DataFrame with the coordinates of the objects found in the window
+
+    Examples
+    --------
+    >>> df = spark.read.format("csv")\
+        .option("inferSchema", True)\
+        .option("header", True)\
+        .load("../src/test/resources/cartesian_spheres_manual.csv")
+
+    Point-like window
+    >>> windowtype = "point"
+    >>> windowcoord = [1.0, 1.0, 1.0]
+    >>> env = windowquery(df.select("x", "y", "z"), windowtype, windowcoord, "cartesian")
+
+    >>> print(env.count())
+    2
+
+    You can add back the metadata
+    >>> envWithMeta = df.join(env, ["x", "y", "z"], "left_semi")
+
+    Sphere-like window
+    >>> windowtype = "sphere"
+    >>> windowcoord = [1.0, 1.0, 1.0, 2.0]
+    >>> env = windowquery(df.select("x", "y", "z"), windowtype, windowcoord, "cartesian")
+
+    >>> print(env.count())
+    3
+
+    Shell-like window
+    >>> windowtype = "shell"
+    >>> windowcoord = [1.0, 1.0, 1.0, 0.0, 2.0]
+    >>> env = windowquery(df.select("x", "y", "z"), windowtype, windowcoord, "cartesian")
+
+    >>> print(env.count())
+    3
+
+    Box-like window
+    >>> windowtype = "box"
+    >>> windowcoord = [2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 2.0]
+    >>> env = windowquery(df.select("x", "y", "z"), windowtype, windowcoord, "cartesian")
+
+    >>> print(env.count())
+    2
+    """
+    prefix = "com.astrolabsoftware.spark3d"
+    scalapath = "{}.Queries.windowQuery".format(prefix)
+    scalaclass = load_from_jvm(scalapath)
+
+    # # To convert python List to Scala Map
+    convpath = "{}.python.PythonClassTag.javaListtoscalaList".format(prefix)
+    conv = load_from_jvm(convpath)
+
+    out = _java2py(get_spark_context() ,scalaclass(df._jdf, windowtype, conv(windowcoord), coordSys))
+
+    return out
+
+
+if __name__ == "__main__":
+    """
+    Run the doctest using
+
+    python queries.py
+
+    If the tests are OK, the script should exit gracefuly, otherwise the
+    failure(s) will be printed out.
+    """
+    import sys
+    import doctest
+    import numpy as np
+
+    from pyspark import SparkContext
+    from pyspark3d import pyspark3d_conf
+    from pyspark3d import load_user_conf
+    from pyspark3d import get_spark_session
+    # Activate the SparkContext for the test suite
+    dic = load_user_conf()
+    conf = pyspark3d_conf("local", "test", dic)
+    sc = SparkContext.getOrCreate(conf=conf)
+
+    # Load the spark3D JAR+deps, and initialise the spark session.
+    # In a pyspark shell, you do not need this.
+    spark = get_spark_session(dicconf=dic)
+
+    # Numpy introduced non-backward compatible change from v1.14.
+    if np.__version__ >= "1.14.0":
+        np.set_printoptions(legacy="1.13")
+
+    # Run the test suite
+    failure_count, test_count = doctest.testmod()
+    sys.exit(failure_count)

--- a/src/main/scala/com/spark3d/Queries.scala
+++ b/src/main/scala/com/spark3d/Queries.scala
@@ -15,21 +15,89 @@
  */
 package com.astrolabsoftware.spark3d
 
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SparkSession
-// import org.apache.spark.sql.functions.udf
-// import org.apache.spark.sql.functions.col
-// import org.apache.spark.sql.functions.lit
+
 import scala.collection.JavaConverters._
 
 import com.astrolabsoftware.spark3d.geometryObjects.Point3D
+import com.astrolabsoftware.spark3d.geometryObjects.ShellEnvelope
+import com.astrolabsoftware.spark3d.geometryObjects.BoxEnvelope
 import com.astrolabsoftware.spark3d.spatialOperator.KNN.KNNStandard
+import com.astrolabsoftware.spark3d.spatialOperator.WindowQuery.windowQueryFromRDD
 
 
 /**
   * Main object containing methods to query 3D data sets.
   */
 object Queries {
+
+  /**
+    * Check if the coordinate system is spherical
+    *
+    * @param coordSys : Name of the coordinate system (spherical or cartesian)
+    * @return true is spherical, false if cartesian. Otherwise raise an error.
+    */
+  def checkIsSpherical(coordSys: String) : Boolean = {
+    coordSys match {
+      case "spherical" => true
+      case "cartesian" => false
+      case _ => throw new AssertionError("""
+        Coordinate system not understood! You must choose between:
+        spherical, cartesian
+        """)
+    }
+  }
+
+  /**
+    * Make a RDD[Point3D] from a DF containing point coordinates.
+    * Cast entries to Double.
+    *
+    * @param df : Input DataFrame
+    * @param inputType : Input Spark SQL type as String.
+    * @param isSpherical : true if coordinate system is spherical, false if cartesian.
+    * @return a RDD[Point3D]
+    */
+  def createPointRDDFromDF(df: DataFrame, inputType: String, isSpherical: Boolean) : RDD[Point3D] = {
+    inputType match {
+      case "DoubleType" => df.rdd.map(x => new Point3D(x.getDouble(0), x.getDouble(1), x.getDouble(2), isSpherical))
+      case "FloatType" => df.rdd.map(x => new Point3D(x.getFloat(0).toDouble, x.getFloat(1).toDouble, x.getFloat(2).toDouble, isSpherical))
+      case "IntegerType" => df.rdd.map(x => new Point3D(x.getInt(0).toDouble, x.getInt(1).toDouble, x.getInt(2).toDouble, isSpherical))
+    }
+  }
+
+  /**
+    * Make a DF with point coordinates from List[(Double, Double, Double)]
+    *
+    * @param listOfCoordinate : Input list of Tuple of 3 Doubles
+    * @param isSpherical : true if coordinate system is spherical, false if cartesian.
+    * @return DataFrame with point coordinates
+    */
+  def createDFFromList(listOfCoordinate: List[(Double, Double, Double)], colnames: Array[String]): DataFrame = {
+    // Load Spark implicits
+    val locSpark = SparkSession.getActiveSession.get
+    import locSpark.implicits._
+
+    // Return a DataFrame
+    locSpark.sparkContext.parallelize(listOfCoordinate).toDF(colnames(0), colnames(1), colnames(2))
+  }
+
+  /**
+    * Make a DF with point coordinates from RDD[Point3D].
+    *
+    * @param rdd : RDD[Point3D]
+    * @param colnames : Array[String] with columnn names.
+    * @return DataFrame with point coordinates
+    */
+  def createDFFromPointRDD(rdd: RDD[Point3D], colnames: Array[String]): DataFrame = {
+    // Load Spark implicits
+    val locSpark = SparkSession.getActiveSession.get
+    import locSpark.implicits._
+
+    // Return a DataFrame
+    rdd.map(x => x.getCoordinate).map(x => (x(0), x(1), x(2))).toDF(colnames(0), colnames(1), colnames(2))
+  }
 
   /**
     * Finds the K nearest neighbors of the query object.
@@ -55,40 +123,103 @@ object Queries {
     }
 
     // Definition of the coordinate system. Spherical or cartesian
-    val isSpherical : Boolean = coordSys match {
-      case "spherical" => true
-      case "cartesian" => false
-      case _ => throw new AssertionError("""
-        Coordinate system not understood! You must choose between:
-        spherical, cartesian
-        """)
-    }
+    val isSpherical : Boolean = checkIsSpherical(coordSys)
 
     // Assume 3 columns have the same dtype.
-    val inputType = df.dtypes(0)._2
+    val inputType : String = df.dtypes(0)._2
 
-    // Map to coordinates to Point3D. Must be Double.
-    val rdd = inputType match {
-      case "DoubleType" => df.rdd.map(x => new Point3D(x.getDouble(0), x.getDouble(1), x.getDouble(2), isSpherical))
-      case "FloatType" => df.rdd.map(x => new Point3D(x.getFloat(0).toDouble, x.getFloat(1).toDouble, x.getFloat(2).toDouble, isSpherical))
-      case "IntegerType" => df.rdd.map(x => new Point3D(x.getInt(0).toDouble, x.getInt(1).toDouble, x.getInt(2).toDouble, isSpherical))
-    }
+    val rdd = createPointRDDFromDF(df, inputType, isSpherical)
 
     // Map target to Point3D
     val targetAsPoint = new Point3D(target(0), target(1), target(2), isSpherical)
 
-    // Perform the KNN search - return an array of Point3D
-    val out = KNNStandard(rdd, targetAsPoint, k, unique)
+    // Perform the KNN search - return a List of Point3D
+    val knnList = KNNStandard(rdd, targetAsPoint, k, unique)
       // Get the coordinates of points
       .map(x => x.getCoordinate)
       // map to Tuple
       .map(x => (x(0), x(1), x(2)))
 
-    // Load Spark implicits
-    val locSpark = SparkSession.getActiveSession.get
-    import locSpark.implicits._
+    createDFFromList(knnList, df.columns)
+  }
 
-    // Return a DataFrame
-    locSpark.sparkContext.parallelize(out).toDF(df.columns(0), df.columns(1), df.columns(2))
+  /**
+    * Perform window query, that is match between DF elements and
+    * a user-defined window (point, sphere, shell, box).
+    *
+    * If windowType =
+    *   - point: windowCoord = List(x, y, z)
+    *   - sphere: windowCoord = List(x, y, z, R)
+    *   - shell: windowCoord = List(x, y, z, Rin, Rout)
+    *   - box: windowCoord = List(x1, y1, z1, x2, y2, z2, x3, y3, z3)
+    * Use (x, y, z) for cartesian or (r, theta, phi) for spherical.
+    * Note that box only accepts cartesian coordinates.
+    *
+    * @param df : Input DataFrame. Must have 3 columns (the coordinate center of objects)
+    * @param windowType : point, shell, sphere, or box.
+    * @param windowCoord : List of Doubles. The coordinates of the window (see doc above).
+    * @param coordSys : String, coordinate system of the points: spherical or cartesian
+    * @return DataFrame with the coordinates of the objects inside the window.
+    */
+  def windowQuery(df: DataFrame, windowType: String, windowCoord: List[Double], coordSys: String) : DataFrame = {
+    // Number of coordinates must be 3
+    val ok = df.columns.size match {
+      case 3 => true
+      case _ => throw new AssertionError("""
+        Input DataFrame must have 3 columns to perform window query (the coordinate center of objects).
+        Use df.select("col1", "col2", "col3")
+      """)
+    }
+
+    // Definition of the coordinate system. Spherical or cartesian
+    val isSpherical : Boolean = checkIsSpherical(coordSys)
+
+    // Assume 3 columns have the same dtype.
+    val inputType : String = df.dtypes(0)._2
+
+    val rdd = createPointRDDFromDF(df, inputType, isSpherical)
+
+    // Map target to Point3D
+    val windowRDD = windowType match {
+      case "point" => {
+        val shape = new Point3D(windowCoord(0), windowCoord(1), windowCoord(2), isSpherical)
+        windowQueryFromRDD(rdd, shape)
+      }
+      case "sphere" => {
+        val shape = new ShellEnvelope(windowCoord(0), windowCoord(1), windowCoord(2), isSpherical, windowCoord(3))
+        windowQueryFromRDD(rdd, shape)
+      }
+      case "shell" => {
+        val shape = new ShellEnvelope(windowCoord(0), windowCoord(1), windowCoord(2), isSpherical, windowCoord(3), windowCoord(4))
+        windowQueryFromRDD(rdd, shape)
+      }
+      case "box" => {
+        val ok = isSpherical match {
+          case true => throw new AssertionError("""
+            Input Box coordinates must have cartesian coordinate!
+            """)
+          case false => true
+        }
+        val p1 = new Point3D(windowCoord(0), windowCoord(1), windowCoord(2), false)
+        val p2 = new Point3D(windowCoord(3), windowCoord(4), windowCoord(5), false)
+        val p3 = new Point3D(windowCoord(6), windowCoord(7), windowCoord(8), false)
+        val shape = new BoxEnvelope(p1, p2, p3)
+        windowQueryFromRDD(rdd, shape)
+      }
+      case _ => throw new AssertionError("""
+        windowType not understood! You must choose between:
+          point, shell, sphere, box
+
+        If windowType =
+         - point: windowCoord = List(x, y, z)
+         - sphere: windowCoord = List(x, y, z, R)
+         - shell: windowCoord = List(x, y, z, Rin, Rout)
+         - box: windowCoord = List(x1, y1, z1, x2, y2, z2, x3, y3, z3)
+        Use (x, y, z) for cartesian or (r, theta, phi) for spherical.
+        Note that box only accepts cartesian coordinates.
+      """)
+    }
+
+    createDFFromPointRDD(windowRDD, df.columns)
   }
 }

--- a/src/main/scala/com/spark3d/spatialOperator/WindowQuery.scala
+++ b/src/main/scala/com/spark3d/spatialOperator/WindowQuery.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 AstroLab Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.astrolabsoftware.spark3d.spatialOperator
+
+import scala.reflect.ClassTag
+
+import com.astrolabsoftware.spark3d.geometryObjects.Shape3D._
+
+import org.apache.spark.rdd.RDD
+
+/**
+  * Handle window query.
+  * Note that window query is just a sub-case of CrossMatch, just one of the
+  * two data sets has only one (potentially extended) element... ;-)
+  */
+object WindowQuery {
+
+  /**
+    * Perform window query, that is match between RDD elements and
+    * a user-defined window (point, shell, box).
+    *
+    * @param rdd: (RDD[A<:Shape3D])
+    *   RDD of 3D objects
+    * @param envelopeWindow : (B<:Shape3D)
+    *   3D envelope inside which the query is performed
+    * @return (RDD[A<:Shape3D]) RDD with only elements of rdd inside the
+    *   envelopeWindow
+    *
+    */
+  def windowQueryFromRDD[A<:Shape3D : ClassTag, B<:Shape3D : ClassTag](
+    rdd: RDD[A], envelopeWindow: B): RDD[A] = {
+      // Just intersection -- need to implement full coverage
+      rdd.filter(element => element.intersects(envelopeWindow))
+  }
+}


### PR DESCRIPTION
This PR re-introduces the Window query method, but with the DataFrame API.

The core of the routine remains untouched (using RDD), but the I/O are different. It takes a DataFrame as input, and return a DataFrame containing the coordinates of the objects found in the window.