### PR TITLE
Bump version from 0.3.0 -> 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.1
+
+- Introducing KNN + DataFrame API ([PR](https://github.com/astrolabsoftware/spark3D/pull/110))
+- Fix wrong ordering when using unique in KNN ([PR](https://github.com/astrolabsoftware/spark3D/pull/111))
+- Introducing Window Query + DataFrame API ([PR](https://github.com/astrolabsoftware/spark3D/pull/112))
+- Rename addSPartitioning -> prePartition ([PR](https://github.com/astrolabsoftware/spark3D/pull/113))
+- Accelerated partitioning (aborted and postponed) ([PR](https://github.com/astrolabsoftware/spark3D/pull/114))
+
 ## 0.3.0
 
 - Complete change of the interface ([PR](https://github.com/astrolabsoftware/spark3D/pull/108)). This includes:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - [07/2018] **Release**: version 0.1.3, 0.1.4, 0.1.5
 - [08/2018] **Release**: version 0.2.0, 0.2.1 (pyspark3d)
 - [09/2018] **Release**: version 0.2.2
-- [11/2018] **Release**: version 0.3.0 (new DataFrame API)
+- [11/2018] **Release**: version 0.3.0, 0.3.1 (new DataFrame API)
 
 <p align="center"><img width="300" src="https://github.com/astrolabsoftware/spark3D/raw/master/pic/spark3d_newapi.png"/>
 </p>

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import xerial.sbt.Sonatype._
 lazy val root = (project in file(".")).
  settings(
    inThisBuild(List(
-     version      := "0.3.0"
+     version      := "0.3.1"
    )),
    // Name of the application
    name := "spark3D",

--- a/docs/01_installation.md
+++ b/docs/01_installation.md
@@ -20,7 +20,7 @@ another version, feel free to contact us. In addition to Spark, the library has 
 You can link spark3D to your project (either `spark-shell` or `spark-submit`) by specifying the coordinates:
 
 ```bash
-toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark3d_2.11:0.3.0" <...>
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark3d_2.11:0.3.1" <...>
 ```
 
 It might not contain the latest features though (see *Building from source*).
@@ -69,7 +69,7 @@ result on the screen, plus details of the coverage at
 First produce a jar of the spark3D library, and then launch a spark-shell by specifying the external dependencies:
 
 ```bash
-toto:~$ JARS="target/scala-2.11/spark3d_2.11-0.3.0.jar,lib/jhealpix.jar"
+toto:~$ JARS="target/scala-2.11/spark3d_2.11-0.3.1.jar,lib/jhealpix.jar"
 toto:~$ PACKAGES="com.github.astrolabsoftware:spark-fits_2.11:0.7.0"
 toto:~$ spark-shell --jars $JARS --packages $PACKAGES
 ```
@@ -83,7 +83,7 @@ scala> // etc...
 Note that if you make a fat jar (that is building with `sbt ++${SCALA_VERSION} assembly` and not `sbt ++${SCALA_VERSION} package`), you do not need to specify external dependencies as they are already included in the resulting jar:
 
 ```bash
-toto:~$ FATJARS="target/scala-2.11/spark3D-assembly-0.3.0.jar"
+toto:~$ FATJARS="target/scala-2.11/spark3D-assembly-0.3.1.jar"
 toto:~$ spark-shell --jars $FATJARS
 ```
 
@@ -188,7 +188,7 @@ and then launch a pyspark shell:
 
 ```bash
 toto:~$ PYSPARK_DRIVER_PYTHON=ipython pyspark \
-  --jars /path/to/target/scala-2.11/spark3D-assembly-0.3.0.jar
+  --jars /path/to/target/scala-2.11/spark3D-assembly-0.3.1.jar
 ```
 
 # Batch mode and provided examples

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -8,7 +8,7 @@ header:
   cta_url: "/docs/installation/"
   caption:
 intro:
-  - excerpt: '<p><font size="6">Spark extension for processing large-scale 3D data sets: Astrophysics, High Energy Physics, Meteorology, ...</font></p><br /><a href="https://github.com/astrolabsoftware/spark3D/releases/tag/0.3.0">Latest release v0.3.0</a>'
+  - excerpt: '<p><font size="6">Spark extension for processing large-scale 3D data sets: Astrophysics, High Energy Physics, Meteorology, ...</font></p><br /><a href="https://github.com/astrolabsoftware/spark3D/releases/tag/0.3.1">Latest release v0.3.1</a>'
 excerpt: '{::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark3D&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark3D&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
 feature_row:
   - image_path:

--- a/pyspark3d/examples/run_knn.sh
+++ b/pyspark3d/examples/run_knn.sh
@@ -4,11 +4,11 @@
 fn="../../src/test/resources/cartesian_spheres.fits"
 fn="../../src/test/resources/cartesian_spheres_manual_knn.csv"
 
-spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
+spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.1.jar" \
   knn.py -inputpath ${fn} \
   -hdu 1 -K 2 -target 0.2 0.2 0.2 --cartesian
 
 # # With Octree
-spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
+spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.1.jar" \
   knn.py -inputpath ${fn} \
   -hdu 1 -part "octree" -npart 10 -K 2 -target 0.2 0.2 0.2 --cartesian

--- a/pyspark3d/examples/run_windowquery.sh
+++ b/pyspark3d/examples/run_windowquery.sh
@@ -3,6 +3,6 @@
 # Raw
 fn="../../src/test/resources/cartesian_spheres_manual.csv"
 
-spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.0.jar" \
+spark-submit --jars "../../target/scala-2.11/spark3D-assembly-0.3.1.jar" \
   windowquery.py -inputpath ${fn} \
   -hdu 1 -windowtype sphere -windowcoord 2.0 1.0 2.0 1.8 --cartesian

--- a/pyspark3d/version.py
+++ b/pyspark3d/version.py
@@ -1,4 +1,4 @@
 # pyspark3d and spark3D have the same version number
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __scala_version__ = "2.11"
 __scala_version_all__ = "2.11.8"


### PR DESCRIPTION
## 0.3.1

- Introducing KNN + DataFrame API ([PR](https://github.com/astrolabsoftware/spark3D/pull/110))
- Fix wrong ordering when using unique in KNN ([PR](https://github.com/astrolabsoftware/spark3D/pull/111))
- Introducing Window Query + DataFrame API ([PR](https://github.com/astrolabsoftware/spark3D/pull/112))
- Rename addSPartitioning -> prePartition ([PR](https://github.com/astrolabsoftware/spark3D/pull/113))
- Accelerated partitioning (aborted and postponed) ([PR](https://github.com/astrolabsoftware/spark3D/pull/114))