### PR TITLE
Octree: check for initial null value when computing the data envelope

### DIFF
--- a/src/main/scala/com/spark3d/Partitioners.scala
+++ b/src/main/scala/com/spark3d/Partitioners.scala
@@ -180,8 +180,8 @@ class Partitioners(df : DataFrame, options: Map[String, String]) extends Seriali
             min(x.minX, y.minX), max(x.maxX, y.maxX),
             min(x.minY, y.minY), max(x.maxY, y.maxY),
             min(x.minZ, y.minZ), max(x.maxZ, y.maxZ)
-          }
-        )
+          )
+        }
       }
     }
 

--- a/src/main/scala/com/spark3d/Partitioners.scala
+++ b/src/main/scala/com/spark3d/Partitioners.scala
@@ -140,7 +140,7 @@ class Partitioners(df : DataFrame, options: Map[String, String]) extends Seriali
         // see https://github.com/JulienPeloton/spark3D/issues/37
         // for the maxLevels and maxItemsPerNode calculations logic
         val maxLevels = floor(log(numPartitionsRaw)/log(8)).asInstanceOf[Int]
-        val maxItemsPerBox = ceil(dataCount/pow(8, maxLevels)).asInstanceOf[Int]
+        val maxItemsPerBox = ceil(dataCount/pow(8, maxLevels + 1)).asInstanceOf[Int]
         if (maxItemsPerBox > Int.MaxValue) {
           throw new AssertionError(
             """
@@ -172,10 +172,15 @@ class Partitioners(df : DataFrame, options: Map[String, String]) extends Seriali
   def getDataEnvelope(): BoxEnvelope = {
     val seqOp: (BoxEnvelope, BoxEnvelope) => BoxEnvelope = {
       (x, y) => {
-        BoxEnvelope.apply(
-          min(x.minX, y.minX), max(x.maxX, y.maxX),
-          min(x.minY, y.minY), max(x.maxY, y.maxY),
-          min(x.minZ, y.minZ), max(x.maxZ, y.maxZ)
+        // Check if x is initially null
+        if (x.getEnvelope.isNull) {
+          BoxEnvelope.apply(y.minX, y.maxX, y.minY, y.maxY, y.minZ, y.maxZ)
+        else {
+          BoxEnvelope.apply(
+            min(x.minX, y.minX), max(x.maxX, y.maxX),
+            min(x.minY, y.minY), max(x.maxY, y.maxY),
+            min(x.minZ, y.minZ), max(x.maxZ, y.maxZ)
+          }
         )
       }
     }

--- a/src/main/scala/com/spark3d/Partitioners.scala
+++ b/src/main/scala/com/spark3d/Partitioners.scala
@@ -175,7 +175,7 @@ class Partitioners(df : DataFrame, options: Map[String, String]) extends Seriali
         // Check if x is initially null
         if (x.getEnvelope.isNull) {
           BoxEnvelope.apply(y.minX, y.maxX, y.minY, y.maxY, y.minZ, y.maxZ)
-        else {
+        } else {
           BoxEnvelope.apply(
             min(x.minX, y.minX), max(x.maxX, y.maxX),
             min(x.minY, y.minY), max(x.maxY, y.maxY),


### PR DESCRIPTION
Linked to issue: #121 

When applying `seqOp` to determine the envelope of the dataset (`Octree.scala`), the first comparison is done between a null BoxEnvelope and a point of the dataset. The null value has coordinate `x=(0, -1, 0, -1, 0, -1)`, and the implicit assumption was that the dataset contains the `(0, 0, 0, 0, 0, 0)` point. But for a dataset completely shifted from the origin, the code was producing a huge envelope (to include the origin), leading to huge empty partitions.