### PR TITLE
Scala visualization tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,24 +56,6 @@ Note that we release the assembly JAR with it.
 ### More information
 
 See the [website](https://astrolabsoftware.github.io/spark3D/)!
-Here is a visualisation of the repartitioning of two datasets:
-
-#### Onion repartitioning
-
-.. raw:: html
-	<div>
-	  <a href="https://plot.ly/~JulienPeloton/211/?share_key=pS2w30RtS4dTlrCrk7HZdX" target="_blank" title="partitioning-out_srcs_s1_0.fits-onion" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/211.png?share_key=pS2w30RtS4dTlrCrk7HZdX" alt="partitioning-out_srcs_s1_0.fits-onion" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
-	  <script data-plotly="JulienPeloton:211" sharekey-plotly="pS2w30RtS4dTlrCrk7HZdX" src="https://plot.ly/embed.js" async></script>
-	</div>
-
-#### Octree repartitioning
-
-.. raw:: html
-	<div>
-	  <a href="https://plot.ly/~JulienPeloton/213/?share_key=6WVgA1daL8PmIRF2HejMxQ" target="_blank" title="partitioning-dc2-octree" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/213.png?share_key=6WVgA1daL8PmIRF2HejMxQ" alt="partitioning-dc2-octree" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
-	  <script data-plotly="JulienPeloton:213" sharekey-plotly="6WVgA1daL8PmIRF2HejMxQ" src="https://plot.ly/embed.js" async></script>
-	</div>
-
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -60,17 +60,19 @@ Here is a visualisation of the repartitioning of two datasets:
 
 #### Onion repartitioning
 
-<div>
-  <a href="https://plot.ly/~JulienPeloton/211/?share_key=pS2w30RtS4dTlrCrk7HZdX" target="_blank" title="partitioning-out_srcs_s1_0.fits-onion" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/211.png?share_key=pS2w30RtS4dTlrCrk7HZdX" alt="partitioning-out_srcs_s1_0.fits-onion" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
-  <script data-plotly="JulienPeloton:211" sharekey-plotly="pS2w30RtS4dTlrCrk7HZdX" src="https://plot.ly/embed.js" async></script>
-</div>
+.. raw:: html
+	<div>
+	  <a href="https://plot.ly/~JulienPeloton/211/?share_key=pS2w30RtS4dTlrCrk7HZdX" target="_blank" title="partitioning-out_srcs_s1_0.fits-onion" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/211.png?share_key=pS2w30RtS4dTlrCrk7HZdX" alt="partitioning-out_srcs_s1_0.fits-onion" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
+	  <script data-plotly="JulienPeloton:211" sharekey-plotly="pS2w30RtS4dTlrCrk7HZdX" src="https://plot.ly/embed.js" async></script>
+	</div>
 
 #### Octree repartitioning
 
-<div>
-  <a href="https://plot.ly/~JulienPeloton/213/?share_key=6WVgA1daL8PmIRF2HejMxQ" target="_blank" title="partitioning-dc2-octree" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/213.png?share_key=6WVgA1daL8PmIRF2HejMxQ" alt="partitioning-dc2-octree" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
-  <script data-plotly="JulienPeloton:213" sharekey-plotly="6WVgA1daL8PmIRF2HejMxQ" src="https://plot.ly/embed.js" async></script>
-</div>
+.. raw:: html
+	<div>
+	  <a href="https://plot.ly/~JulienPeloton/213/?share_key=6WVgA1daL8PmIRF2HejMxQ" target="_blank" title="partitioning-dc2-octree" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/213.png?share_key=6WVgA1daL8PmIRF2HejMxQ" alt="partitioning-dc2-octree" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
+	  <script data-plotly="JulienPeloton:213" sharekey-plotly="6WVgA1daL8PmIRF2HejMxQ" src="https://plot.ly/embed.js" async></script>
+	</div>
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![codecov](https://codecov.io/gh/astrolabsoftware/spark3D/branch/master/graph/badge.svg)](https://codecov.io/gh/astrolabsoftware/spark3D)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.astrolabsoftware/spark3d_2.11/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.astrolabsoftware/spark3d_2.11)
 
-**The package is under an active development!**
-
 ## Latest News
 
 - [05/2018] **GSoC 2018**: spark3D has been selected to the Google Summer of Code (GSoC) 2018. Congratulation to [@mayurdb](https://github.com/mayurdb) who will work on the project this year!
@@ -57,7 +55,23 @@ Note that we release the assembly JAR with it.
 
 ### More information
 
-See our [website](https://astrolabsoftware.github.io/spark3D/)!
+See the [website](https://astrolabsoftware.github.io/spark3D/)!
+Here is a visualisation of the repartitioning of two datasets:
+
+#### Onion repartitioning
+
+<div>
+  <a href="https://plot.ly/~JulienPeloton/211/?share_key=pS2w30RtS4dTlrCrk7HZdX" target="_blank" title="partitioning-out_srcs_s1_0.fits-onion" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/211.png?share_key=pS2w30RtS4dTlrCrk7HZdX" alt="partitioning-out_srcs_s1_0.fits-onion" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
+  <script data-plotly="JulienPeloton:211" sharekey-plotly="pS2w30RtS4dTlrCrk7HZdX" src="https://plot.ly/embed.js" async></script>
+</div>
+
+#### Octree repartitioning
+
+<div>
+  <a href="https://plot.ly/~JulienPeloton/213/?share_key=6WVgA1daL8PmIRF2HejMxQ" target="_blank" title="partitioning-dc2-octree" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/213.png?share_key=6WVgA1daL8PmIRF2HejMxQ" alt="partitioning-dc2-octree" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
+  <script data-plotly="JulienPeloton:213" sharekey-plotly="6WVgA1daL8PmIRF2HejMxQ" src="https://plot.ly/embed.js" async></script>
+</div>
+
 
 ## Contributors
 

--- a/docs/03_visualisation_scala.md
+++ b/docs/03_visualisation_scala.md
@@ -5,4 +5,37 @@ title: "Tutorial: Visualisation"
 date: 2018-06-18 22:31:13 +0200
 ---
 
-Under construction
+# Tutorial: Visualise your partitioning
+
+In many cases, we would like to perform some visual inspection of the partitioning, but displaying large data sets is not a trivial task. The approach here consists in repartitioning the data set, and sampling the data for the display. The colour code corresponds to partition ID.
+
+## Before starting
+
+We provide a script based on the [Scala client of Plotly](https://github.com/facultyai/scala-plotly-client). Unfortunately, the releases on Maven are not up-to-date (e.g. they do not contain the code to make Scatter3D plots), hence we compiled the latest sources and released the JAR under `$spark3d/lib`. You will also find a bash script to help running it:
+
+```bash
+# in $spark3d
+./run_viz_scala.sh
+```
+
+Just adapt the input parameters according to your data and cluster configuration. You will also need to open an account on plotly, and provide your username and api key in the bash script. The plots will then be available in your plotly home.
+
+## Some examples
+
+### Onion repartitioning
+
+We repartitioned a dataset containing data in spherical coordinates using the `onion` partitioning scheme. Only a fraction of the total dataset is used for plot:
+
+<div>
+    <a href="https://plot.ly/~JulienPeloton/223/?share_key=AWsciidRkVB4Bb4Ur2WJQg" target="_blank" title="partitioning-out_srcs_s1_1*.fits-onion-spark3dweb" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/223.png?share_key=AWsciidRkVB4Bb4Ur2WJQg" alt="partitioning-out_srcs_s1_1*.fits-onion-spark3dweb" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
+    <script data-plotly="JulienPeloton:223" sharekey-plotly="AWsciidRkVB4Bb4Ur2WJQg" src="https://plot.ly/embed.js" async></script>
+</div>
+
+### Octree repartitioning
+
+We repartitioned a dataset containing data in cartesian coordinates using the `octree` partitioning scheme. Only a fraction of the total dataset is used for plot:
+
+<div>
+    <a href="https://plot.ly/~JulienPeloton/225/?share_key=01FRN2snL0QWpSHefu2PqH" target="_blank" title="partitioning-dc2-octree-spark3dweb" style="display: block; text-align: center;"><img src="https://plot.ly/~JulienPeloton/225.png?share_key=01FRN2snL0QWpSHefu2PqH" alt="partitioning-dc2-octree-spark3dweb" style="max-width: 100%;width: 600px;"  width="600" onerror="this.onerror=null;this.src='https://plot.ly/404.png';" /></a>
+    <script data-plotly="JulienPeloton:225" sharekey-plotly="01FRN2snL0QWpSHefu2PqH" src="https://plot.ly/embed.js" async></script>
+</div>

--- a/run_viz_scala.sh
+++ b/run_viz_scala.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+SCAlA_VERSION=2.11
+VERSION=0.3.1
+
+# Compile the code
+sbt ++2.11.8 package
+
+PACK=com.github.astrolabsoftware:spark-fits_2.11:0.7.1
+SF=target/scala-2.11/spark3d_2.11-${VERSION}.jar
+HP=lib/jhealpix.jar,lib/plotly-assembly-0.3.0-SNAPSHOT.jar
+
+MASTERURL=yarn
+inputfn="LSST1Y/out_srcs_s1_0.fits"
+
+spark-submit \
+    --master ${MASTERURL} \
+    --driver-memory 4g --executor-memory 28g --executor-cores 17 --total-executor-cores 102 \
+    --jars ${SF},${HP} --packages ${PACK} \
+    --class com.astrolabsoftware.spark3d.examples.VisualizePart \
+    target/scala-${SCAlA_VERSION}/spark3d_${SCAlA_VERSION}-${VERSION}.jar \
+    $inputfn "Z_COSMO,RA,DEC" true "onion" 8 0.0001 "JulienPeloton" "TFdIOAdqlKNEl7HpybA1"
+
+inputfn="dc2"
+spark-submit \
+    --master ${MASTERURL} \
+    --driver-memory 4g --executor-memory 28g --executor-cores 17 --total-executor-cores 102 \
+    --jars ${SP},${HP} --packages ${PACK} \
+    --class com.astrolabsoftware.spark3d.examples.VisualizePart \
+    target/scala-${SCAlA_VERSION}/spark3d_${SCAlA_VERSION}-${VERSION}.jar \
+    $inputfn "position_x_mock,position_y_mock,position_z_mock" false "octree" 512 0.001 "JulienPeloton" "TFdIOAdqlKNEl7HpybA1"

--- a/run_viz_scala.sh
+++ b/run_viz_scala.sh
@@ -19,7 +19,7 @@ spark-submit \
     --jars ${SF},${HP} --packages ${PACK} \
     --class com.astrolabsoftware.spark3d.examples.VisualizePart \
     target/scala-${SCAlA_VERSION}/spark3d_${SCAlA_VERSION}-${VERSION}.jar \
-    $inputfn "Z_COSMO,RA,DEC" true "onion" 8 0.0001 "JulienPeloton" "TFdIOAdqlKNEl7HpybA1"
+    $inputfn "Z_COSMO,RA,DEC" true "onion" 8 0.0001 "username" "api_key"
 
 inputfn="dc2"
 spark-submit \
@@ -28,4 +28,4 @@ spark-submit \
     --jars ${SP},${HP} --packages ${PACK} \
     --class com.astrolabsoftware.spark3d.examples.VisualizePart \
     target/scala-${SCAlA_VERSION}/spark3d_${SCAlA_VERSION}-${VERSION}.jar \
-    $inputfn "position_x_mock,position_y_mock,position_z_mock" false "octree" 512 0.001 "JulienPeloton" "TFdIOAdqlKNEl7HpybA1"
+    $inputfn "position_x_mock,position_y_mock,position_z_mock" false "octree" 512 0.001 "username" "api_key"

--- a/src/main/scala/com/spark3d/examples/VisualizePart.scala
+++ b/src/main/scala/com/spark3d/examples/VisualizePart.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Julien Peloton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.astrolabsoftware.spark3d.examples
+
+// spark3D implicits
+import com.astrolabsoftware.spark3d._
+import com.astrolabsoftware.spark3d.utils.Utils._
+import com.astrolabsoftware.spark3d.geometryObjects.Point3D
+
+// Spark lib
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+
+// Logger
+import org.apache.log4j.Level
+import org.apache.log4j.Logger
+
+import co.theasi.plotly._
+
+object VisualizePart {
+  // Set to Level.WARN is you want verbosity
+  Logger.getLogger("org").setLevel(Level.WARN)
+  Logger.getLogger("akka").setLevel(Level.WARN)
+
+  // Initialise our spark connector
+  val spark = SparkSession
+    .builder()
+    .appName("visualisation")
+    .getOrCreate()
+
+  import spark.implicits._
+
+  /**
+    * Main
+    */
+  def main(args : Array[String]) = {
+
+    if (args.size < 8) {
+      println("""
+        Repartition and visualise 3D dataset using plotly.
+        The final drawing is always in cartesian coordinates.
+
+        Usage:
+        --class com.astrolabsoftware.spark3d.examples.VisualizePart \
+        <inputfile> <colnames> <coordSys> <partitionMethod> \
+        <npartitions> <fractoplot> <plotly_username> <plotly_api_key>
+      """)
+    }
+
+    // Data file
+    val inputFile = args(0).toString
+
+    // Column names
+    val columns = args(1).toString
+
+    // coordSys
+    val coordSys : String = args(2).toBoolean match {
+        case true => "spherical"
+        case false => "cartesian"
+    }
+
+    // partitioning
+    val grid = args(3).toString
+
+    // partitions
+    val part = args(4).toInt
+
+    // partitions
+    val fracToPlot = args(5).toDouble
+
+    implicit val server = new writer.Server {
+      val credentials = writer.Credentials(args(6).toString, args(7).toString)
+      val url = "https://api.plot.ly/v2/"
+    }
+
+    // Load the data
+    val df = if (inputFile.endsWith("fits")) {
+      spark.read.format("fits").option("hdu", 1).load(inputFile)
+    } else {
+      spark.read.format("parquet").load(inputFile)
+    }
+    val options = Map(
+        "geometry" -> "points",
+        "colnames" -> columns,
+        "coordSys" -> coordSys,
+        "gridtype" -> grid)
+
+    val df_colid = df.prePartition(options, part)
+    val df_repart = df_colid.repartitionByCol("partition_id", true, part)
+
+    val splitColnames = columns.split(",")
+
+    val partitionData = df_repart.sample(false, fracToPlot)
+     .select(splitColnames(0), splitColnames(1), splitColnames(2))
+     .rdd.glom()
+     .collect()
+
+    var plot = ThreeDPlot()
+
+    for (partIndex <- 0 to partitionData.size - 1) {
+      // Change coordinate system to cartesian
+      val partitionDataCart = if (coordSys == "cartesian") {
+        partitionData(partIndex)
+          .map(x => List(x.getDouble(0), x.getDouble(1), x.getDouble(2))).toList
+      } else {
+        partitionData(partIndex)
+          .map(x => List(x.getFloat(0), dec2theta(x.getFloat(2)), ra2phi(x.getFloat(1))))
+          .map(x => new Point3D(x(0), x(1), x(2), true))
+          .map(p => sphericalToCartesian(p).getCoordinate).toList
+      }
+
+      val meanxt = partitionDataCart.map(x => x.asInstanceOf[List[Double]](0)).toList
+      val meanyt = partitionDataCart.map(x => x.asInstanceOf[List[Double]](1)).toList
+      val meanzt = partitionDataCart.map(x => x.asInstanceOf[List[Double]](2)).toList
+
+      val markers = if (coordSys == "cartesian") {
+        List(ScatterMode.Marker, ScatterMode.Line)
+      } else List(ScatterMode.Marker)
+
+      plot = plot.withScatter(meanxt, meanyt, meanzt, ScatterOptions()
+        .mode(markers)
+        .name(s"Partition $partIndex")
+        .marker(MarkerOptions().size(2)))
+    }
+
+    // Remove /'s in filename
+    val fName = inputFile.split("/").reverse.head
+    draw(plot, s"partitioning-$fName-$grid")
+
+  }
+}


### PR DESCRIPTION
Linked to issue: #122 

In many cases, we would like to perform some visual inspection of the partitioning, but displaying large data sets is not a trivial task. The approach of this PR consists in repartitioning the DataFrame, and sampling the data for the display. The display is done using a [scala client of plotly](https://github.com/facultyai/scala-plotly-client). 

For more information about the resulting plots, see the [spark3D website](https://astrolabsoftware.github.io/spark3D/docs/visualisation/scala/).